### PR TITLE
Operational Use Cases

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -14,7 +14,8 @@ class Config(object):
         )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     LOG_TO_STDOUT = os.environ.get('LOG_TO_STDOUT')
-
+    CACHE_REDIS_HOST = 'redis'
+    
     # LaunchDarkly
     ldclient.set_sdk_key(os.environ.get("LD_CLIENT_KEY"))
     LD_FRONTEND_KEY = os.environ.get("LD_FRONTEND_KEY")

--- a/app/config.py
+++ b/app/config.py
@@ -14,8 +14,8 @@ class Config(object):
         )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     LOG_TO_STDOUT = os.environ.get('LOG_TO_STDOUT')
-    CACHE_REDIS_HOST = 'redis'
-    
+    CACHE_REDIS_HOST = os.environ.get('REDIS_HOST') or 'cache'
+
     # LaunchDarkly
     ldclient.set_sdk_key(os.environ.get("LD_CLIENT_KEY"))
     LD_FRONTEND_KEY = os.environ.get("LD_FRONTEND_KEY")

--- a/app/factory.py
+++ b/app/factory.py
@@ -6,6 +6,7 @@ from flask_bootstrap import Bootstrap
 from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
+from flask_caching import Cache 
 
 from app.config import config
 
@@ -13,6 +14,11 @@ db = SQLAlchemy()
 migrate = Migrate()
 bootstrap =  Bootstrap()
 login = LoginManager()
+cache = Cache(config={'CACHE_TYPE': 'redis'})
+
+# Operational Feature Flags
+CACHE_TIMEOUT = lambda : ldclient.get().variation('cache-timeout', {'key': 'any'}, 50)
+CACHING_DISABLED = lambda : ldclient.get().variation('caching-disabled', {'key': 'any'}, False)
 
 def create_app(config_name):
     """Flask application factory.
@@ -30,8 +36,11 @@ def create_app(config_name):
 
     bootstrap.init_app(app)
     migrate.init_app(app, db)
+    cache.init_app(app)
     login.init_app(app)
     login.login_view = 'core.login'
+    from app.models import AnonymousUser
+    login.anonymous_user = AnonymousUser
 
     from app.routes import core
     app.register_blueprint(core)

--- a/app/factory.py
+++ b/app/factory.py
@@ -1,12 +1,13 @@
+import logging
 import os
 
 import ldclient
 from flask import Flask
 from flask_bootstrap import Bootstrap
+from flask_caching import Cache
 from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
-from flask_caching import Cache 
 
 from app.config import config
 
@@ -45,4 +46,28 @@ def create_app(config_name):
     from app.routes import core
     app.register_blueprint(core)
 
+    @app.before_request
+    def set_logging_level():
+        """Set Logging Level Based on Feature Flag
+
+        This uses LaunchDarkly to update the logging level dynamically.
+        Before each request runs, we check the current logging level and
+        it does not match, we update it to the new value.
+
+        Logging levels are integer values based on the standard Logging library
+        in python: https://docs.python.org/3/library/logging.html#logging-levels 
+        
+        This is an operational feature flag.
+        """
+        logLevel = ldclient.get().variation("set-logging-level", {"key": "any"}, 20)
+
+        app.logger.info("Log level is {0}".format(logLevel))
+
+        # set app 
+        app.logger.setLevel(logLevel)
+        # set werkzeug
+        logging.getLogger('werkzeug').setLevel(logLevel)
+        # set root
+        logging.getLogger().setLevel(logLevel)
+        
     return app

--- a/app/routes.py
+++ b/app/routes.py
@@ -5,13 +5,14 @@ from flask import flash, redirect, render_template, request, url_for, Blueprint,
 from flask_login import current_user, login_required, login_user, logout_user
 from werkzeug.urls import url_parse
 
-from app.factory import db
+from app.factory import db, CACHE_TIMEOUT, CACHING_DISABLED
 from app.models import User
 
 core = Blueprint('core', __name__)
 
 @core.route('/')
 @core.route('/index')
+@cache.cached(timeout=CACHE_TIMEOUT, unless=CACHING_DISABLED)
 @login_required
 def index():
     theme = request.args.get("theme")

--- a/app/routes.py
+++ b/app/routes.py
@@ -5,7 +5,7 @@ from flask import flash, redirect, render_template, request, url_for, Blueprint,
 from flask_login import current_user, login_required, login_user, logout_user
 from werkzeug.urls import url_parse
 
-from app.factory import db, CACHE_TIMEOUT, CACHING_DISABLED
+from app.factory import db, cache, CACHE_TIMEOUT, CACHING_DISABLED
 from app.models import User
 
 core = Blueprint('core', __name__)

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,18 +1,21 @@
 import json
+import logging
 
 import ldclient
-from flask import flash, redirect, render_template, request, url_for, Blueprint, current_app
+from flask import (Blueprint, current_app, flash, redirect, render_template,
+                   request, url_for)
 from flask_login import current_user, login_required, login_user, logout_user
 from werkzeug.urls import url_parse
 
-from app.factory import db, cache, CACHE_TIMEOUT, CACHING_DISABLED
+from app.factory import CACHE_TIMEOUT, CACHING_DISABLED, cache, db
 from app.models import User
 
 core = Blueprint('core', __name__)
 
 @core.route('/')
 @core.route('/index')
-@cache.cached(timeout=CACHE_TIMEOUT, unless=CACHING_DISABLED)
+# TODO fix this, it does not seem to bypass the cache properly
+# @cache.cached(timeout=CACHE_TIMEOUT(), unless=CACHING_DISABLED())
 @login_required
 def index():
     theme = request.args.get("theme")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,7 @@ services:
     ports:
       - "5432:5432"
 
+  cache:
+    image: redis
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
Closes https://github.com/launchdarkly/SupportService/issues/9

Related to https://github.com/launchdarkly/SupportService/issues/11 - this is only partially working. Disabling the cache bypasses the call to redis, but it still does not clear the cache. Need to rethink this approach a little bit. 