### PR TITLE
add lambda function to handle new environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ test-reports/
 venv/
 *.env
 secrets.sh
+lambda/
+*.zip

--- a/LdLambda.py
+++ b/LdLambda.py
@@ -1,0 +1,47 @@
+"""
+ld_lambda
+
+Process LaunchDarkly webhooks to trigger a CI build when
+a new environment is created. 
+"""
+import os
+import json
+import logging
+
+from circleci.api import Api
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+circleci = Api(os.environ.get("CIRCLE_TOKEN"))
+
+def trigger_deloy():
+    params = {
+        'build_parameters[CIRCLE_JOB]': 'deploy'
+    }
+
+    circleci.trigger_build(
+        username='launchdarkly',
+        project='SupportService',
+        params=params
+    )
+
+def handler(event, context):
+    """
+    AWS Lambda Handler
+    """
+    payload = json.loads(event['body'])
+    action = payload['accesses'][0]['action']
+    
+    if  action == 'createEnvironment':
+        logger.info("Triggering Deploy for New Environment")
+        trigger_deloy()
+    else:
+        logger.info("Nothing to do for {0}".format(action))
+
+    return {
+        'payload': payload
+    }
+
+# debug
+if __name__ == '__main__':
+    trigger_deloy()

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,7 @@ run:
 
 test:
 	set -e && coverage run tests/main.py
+
+update:
+	zip -g LdLambda.zip LdLambda.py && \
+	scripts/update_lambda.sh

--- a/scripts/create_lambda.sh
+++ b/scripts/create_lambda.sh
@@ -1,0 +1,10 @@
+aws lambda create-function \
+    --region $AWS_DEFAULT_REGION \
+    --function-name LdLambda \
+    --zip-file fileb://LdLambda.zip \
+    --role $AWS_LAMBDA_ROLE_ARN \
+    --handler LdLambda.handler \
+    --runtime python3.6 \
+    --timeout 15 \
+    --memory-size 128
+

--- a/scripts/package_lambda.sh
+++ b/scripts/package_lambda.sh
@@ -1,0 +1,8 @@
+SITE_PACKAGES="lambda/lib/python3.6/site-packages"
+DIR=$(pwd)
+
+cd $SITE_PACKAGES
+zip -r9 $DIR/LdLambda.zip *
+
+cd $DIR
+zip -g LdLambda.zip LdLambda.py

--- a/scripts/update_lambda.sh
+++ b/scripts/update_lambda.sh
@@ -1,0 +1,3 @@
+aws lambda update-function-code \
+    --function-name LdLambda \
+    --zip-file fileb://LdLambda.zip

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'redis',
         'ldclient-py',
         'gunicorn',
-        'boto3'
+        'boto3',
+        'circleci'
     ]
 )


### PR DESCRIPTION
This function is currently deployed to lambda. When a new environment is created in LaunchDarkly, it will trigger a new deploy on CircleCI and automatically provision a new lightsail instance. 