### PR TITLE
add smoke test to docker compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,17 +55,17 @@ jobs:
           path: test-reports
 
   build_docker:
-    docker:
-      - image: circleci/python:3.6
+    machine:
     steps:
       - checkout
-      - setup_remote_docker
-      # removing because docker aleady exists in circleci/python
-      # - run:
-      #     name: Install Docker client
-      #     command: |
-      #       curl -fsSL get.docker.com -o get-docker.sh
-      #       sudo sh get-docker.sh
+      - run:
+          name: Install Docker client
+          command: |
+            curl -fsSL get.docker.com -o get-docker.sh
+            sudo sh get-docker.sh
+      - run:
+          name: Install Docker Compose
+          command: sudo pip install docker-compose
       - run:
           name: Build Image
           command: |
@@ -73,6 +73,9 @@ jobs:
             docker tag levlaz/supportservice:$CIRCLE_SHA1 levlaz/supportservice:latest
             docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
             docker push levlaz/supportservice
+      - run:
+          name: Test Stack
+          command: docker-compose -f docker-compose.prod.yml up
 
   deploy:
     docker:
@@ -114,7 +117,9 @@ workflows:
             - test
           filters:
             branches:
-              only: master
+              only: 
+                - master
+                - machine
       - deploy:
           requires:
             - build_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,11 +59,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install Docker client
-          command: |
-            curl -fsSL get.docker.com -o get-docker.sh
-            sudo sh get-docker.sh
-      - run:
           name: Install Docker Compose
           command: sudo pip install docker-compose
       - run:
@@ -71,11 +66,14 @@ jobs:
           command: |
             docker build -t levlaz/supportservice:$CIRCLE_SHA1 -f Dockerfile.prod .
             docker tag levlaz/supportservice:$CIRCLE_SHA1 levlaz/supportservice:latest
-            docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
-            docker push levlaz/supportservice
       - run:
           name: Test Stack
           command: docker-compose -f docker-compose.prod.yml up
+      - run:
+          name: Push Image
+          command: |
+            docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+            docker push levlaz/supportservice
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           name: Test Stack
           command: |
             export DATABASE_URL=postgresql://supportService:supportService@db/supportService
-            docker-compose -f docker-compose.prod.yml up
+            docker-compose -f docker-compose.prod.yml up -d
       - run:
           name: Push Image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,9 +117,7 @@ workflows:
             - test
           filters:
             branches:
-              only: 
-                - master
-                - machine
+              only: master
       - deploy:
           requires:
             - build_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
           path: test-reports
 
   build_docker:
-    machine:
+    machine: true
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,9 @@ jobs:
             docker tag levlaz/supportservice:$CIRCLE_SHA1 levlaz/supportservice:latest
       - run:
           name: Test Stack
-          command: docker-compose -f docker-compose.prod.yml up
+          command: |
+            export DATABASE_URL=postgresql://supportService:supportService@db/supportService
+            docker-compose -f docker-compose.prod.yml up
       - run:
           name: Push Image
           command: |


### PR DESCRIPTION
Add some basic smoke tests to docker compose. This ensures that at the very least the stack will start up before we deploy to production using the latest docker image. 