### PR TITLE
Fix syntax error in boto client instantiation.

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -228,9 +228,16 @@ def upgrade():
 
 def fetch_aws_embed_url():
     """
-    This function is used to generate a new embedded url key each time the data export page is requested
+    This function is used to generate a new embedded url 
+    key each time the data export page is requested
     """
-    client = boto3.client('quicksight', region_name='us-west-2', aws_quicksight_access_key_id= current_app.config['AWS_QUICKSIGHT_ACCESS_KEY_ID'], aws_quicksight_secret_access_key_id = current_app.config['AWS_QUICKSIGHT_SECRET_ACCESS_KEY_ID'])
+    client = boto3.client(
+        'quicksight', 
+        region_name = 'us-west-2', 
+        aws_access_key_id = current_app.config['AWS_QUICKSIGHT_ACCESS_KEY_ID'],
+        aws_secret_access_key = current_app.config['AWS_QUICKSIGHT_SECRET_ACCESS_KEY_ID']
+    )
+
     response = client.get_dashboard_embed_url(
         AwsAccountId='955116512041',
         DashboardId='3d69e3e3-304c-480c-8388-c26bddfa7912',


### PR DESCRIPTION
The function arguments were not named correctly when
instantiating the boto3 client. We are now using the correct
function argument names as described in the documentation.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client