### PR TITLE
Speed Up Machine Build Step on CircleCI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,19 +49,16 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v6-machine-dependencies-{{ checksum "setup.py" }}
-            - v6-machine-dependencies-
+            - v7-machine-dependencies-{{ checksum "setup.py" }}
+            - v7-machine-dependencies-
       - run:
           name: install dependencies
           command: |
-            virtualenv venv
-            . venv/bin/activate
-            pip install -r dev-requirements.txt
             pip install -e .
       - save_cache:
           paths:
-            - ./venv
-          key: v6-machine-dependencies-{{ checksum "setup.py" }}
+            - ./opt/circleci/.pyenv
+          key: v7-machine-dependencies-{{ checksum "setup.py" }}
       - run:
           name: Install Docker Compose
           command: sudo curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -79,7 +76,6 @@ jobs:
       - run:
           name: Test Production Stack
           command: |
-            . venv/bin/activate
             make generate
             mkdir -p etc/nginx
             mv nginx.conf etc/nginx

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-machine-dependencies-{{ checksum "setup.py" }}
-            - v5-machine-dependencies-
+            - v6-machine-dependencies-{{ checksum "setup.py" }}
+            - v6-machine-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -61,7 +61,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v5-machine-dependencies-{{ checksum "setup.py" }}
+          key: v6-machine-dependencies-{{ checksum "setup.py" }}
       - run:
           name: Install Docker Compose
           command: sudo curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,15 +8,12 @@ jobs:
           POSTGRES_USER: supportService
           POSTGRES_DB: supportService
           POSTGRES_PASSWORD: supportService
-
     steps:
       - checkout
-
       - restore_cache:
           keys:
             - v3-dependencies-{{ checksum "setup.py" }}
             - v3-dependencies-
-
       - run:
           name: install dependencies
           command: |
@@ -24,18 +21,15 @@ jobs:
             . venv/bin/activate
             pip install -r dev-requirements.txt
             pip install -e .
-
       - save_cache:
           paths:
             - ./venv
           key: v3-dependencies-{{ checksum "setup.py" }}
-
       - run:
           name: run tests
           command: |
             . venv/bin/activate
             make test
-
       - run:
           name: generate coverage report
           when: always
@@ -43,37 +37,31 @@ jobs:
             . venv/bin/activate
             coverage html
             codecov
-
       - store_test_results:
           path: test-reports
-
       - store_artifacts:
           path: htmlcov
-
       - store_artifacts:
           path: test-reports
-
   build_docker:
     machine: true
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v4-machine-dependencies-{{ checksum "setup.py" }}
-            - v4-machine-dependencies-
+            - v5-machine-dependencies-{{ checksum "setup.py" }}
+            - v5-machine-dependencies-
       - run:
           name: install dependencies
           command: |
-            pyenv install 3.6.3
-            pyenv global 3.6.3
-            python -m venv venv
+            virtualenv venv
             . venv/bin/activate
             pip install -r dev-requirements.txt
             pip install -e .
       - save_cache:
           paths:
             - ./venv
-          key: v4-machine-dependencies-{{ checksum "setup.py" }}
+          key: v5-machine-dependencies-{{ checksum "setup.py" }}
       - run:
           name: Install Docker Compose
           command: sudo curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -135,7 +123,6 @@ jobs:
             . venv/bin/activate
             make generate
             ./scripts/deploy.sh
-
   simulate:
     docker:
       - image: circleci/openjdk:8-node-browsers
@@ -151,7 +138,6 @@ jobs:
           command: |
             cd tests/webdriver
             java -jar target/webdriver-1.0-SNAPSHOT-jar-with-dependencies.jar
-
 workflows:
   version: 2
   build_test_deploy:
@@ -166,7 +152,6 @@ workflows:
           filters:
             branches:
               only: master
-
   # Run simulator every hour
   simulator:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,16 +49,16 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v7-machine-dependencies-{{ checksum "setup.py" }}
-            - v7-machine-dependencies-
+            - v8-machine-dependencies-{{ checksum "setup.py" }}
+            - v8-machine-dependencies-
       - run:
           name: install dependencies
           command: |
             pip install -e .
       - save_cache:
           paths:
-            - ./opt/circleci/.pyenv
-          key: v7-machine-dependencies-{{ checksum "setup.py" }}
+            - /opt/circleci/.pyenv
+          key: v8-machine-dependencies-{{ checksum "setup.py" }}
       - run:
           name: Install Docker Compose
           command: sudo curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose


### PR DESCRIPTION
Python3.5 (the default version on the machine executor) was having some issues with our setup. I tried to solve it by installing Python3.6 with pyenv but this added 2+ minutes to every single build.

I tested everything out with Python2 and it works like a charm. This PR significantly reduces the build time for testing and creating new docker containers.