### PR TITLE
[WIP] Bootstrap popup

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -53,9 +53,7 @@ def dashboard():
         updateTheme(theme)
 
     beta_features = ldclient.get().variation('dark-theme', current_user.get_ld_user(), False)
-
     set_theme = '{0}/index.html'.format(current_user.set_path)
-
     return render_template(set_theme, title='Home', show_beta=beta_features)
 
 def updateTheme(theme):
@@ -80,10 +78,10 @@ def experiments():
     set_theme = '{0}/exp.html'.format(current_user.set_path)
 
     random_user = current_user.get_random_ld_user()
-
     show_nps = ldclient.get().variation('show-nps-survery', random_user, False)
+    bootstrap_client = ldclient.get().all_flags_state(random_user, client_side_only=True)
 
-    return render_template(set_theme, title='Experiments', show_nps=show_nps, random_user=random_user)
+    return render_template(set_theme, title='Experiments', show_nps=show_nps, random_user=random_user, ldBootstrap=bootstrap_client.to_json_string())
 
 @core.route('/operational')
 def operational():

--- a/app/templates/default/exp.html
+++ b/app/templates/default/exp.html
@@ -570,7 +570,21 @@
 
     // JQuery to populate NPS buttons
     $(document).ready(function() {
-                
+        // Use bootstrapping method to provide immediate values to javascript client
+        var ldclient = LDClient.initialize("{{ config['LD_FRONTEND_KEY'] }}", {{ current_user.get_ld_user() | safe }}, options = {bootstrap: {{ ldBootstrap | safe }} } );
+        ldclient.identify({{ random_user | safe }}, null, function() {
+            console.log("Testing");
+        });
+
+        ldclient.on('ready', function() {
+
+            var showNps = ldclient.variation("show-nps-survery", false);
+
+            if (showNps){
+                $('#launchNps').modal('show');
+            }
+        })
+
         for(i=1;i<=10;i++){
             $("#nps_container").append(generateNpsButton(i));
         }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "amazon-quicksight-embedding-sdk": "^1.0.3",
     "jquery": "^3.4.0",
     "startbootstrap-sb-admin-2": "^4.0.3",
-    "lodash": ">=4.17.11"
+    "lodash": "~4.17.13"
   },
   "devDependencies": {
     "browserify": "^16.2.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ psycopg2-binary==2.8.2
 redis==3.2.1
 
 # Vendor Dependencies
-ldclient-py==6.9.1
+launchdarkly-server-sdk==6.9.3
 launchdarkly-api==2.0.15
 
 # Runtime


### PR DESCRIPTION
This adds client-side bootstrapping from the python SDK to immediate popup the NPS survey if turned on.

Package Updates:
- replace `ldclient-py` with `launchdarkly-server-sdk`
- update lodash to resolve security alert.