### PR TITLE
Use custom Env Vars if provided, otherwise fallback to default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ export LD_CLIENT_KEY=
 export LD_FRONTEND_KEY=
 
 # Optional
-# Leave LD_RELAY_*_URL blank unless you want to connect to a relay instance. If only LD_RELAY is set, all 3 types of connections will use it.
+# Leave LD_RELAY_*URL blank unless you want to connect to a relay instance. If only LD_RELAY is set, all 3 types of connections will use it.
 # export LD_RELAY_URL=
 # export LD_RELAY_EVENTS_URL=
 # export LD_RELAY_STREAM_URL=

--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,9 @@ export LD_CLIENT_KEY=
 export LD_FRONTEND_KEY=
 
 # Optional
-# Leave RELAY_URL blank unless you want to connect to a relay instance
+# Leave LD_RELAY_*_URL blank unless you want to connect to a relay instance. If only LD_RELAY is set, all 3 types of connections will use it.
 # export LD_RELAY_URL=
+# export LD_RELAY_EVENTS_URL=
+# export LD_RELAY_STREAM_URL=
 # Leave LD_API_KEY blank unless you need to connect to the API
 # export LD_API_KEY=

--- a/app/config.py
+++ b/app/config.py
@@ -58,8 +58,8 @@ class Config(object):
         config = LdConfig(
             sdk_key = LD_CLIENT_KEY,
             base_uri = os.environ.get("LD_RELAY_URL"),
-            events_uri = os.environ.get("LD_RELAY_URL"),
-            stream_uri = os.environ.get("LD_RELAY_URL")
+            events_uri = os.environ.get("LD_RELAY_EVENTS_URL", base_uri),
+            stream_uri = os.environ.get("LD_RELAY_STREAM_URL", base_uri)
         )
         ldclient.set_config(config)
     else:
@@ -71,7 +71,6 @@ class Config(object):
     @staticmethod
     def init_app(app):
         pass
-
 
 class DevelopmentConfig(Config):
     """Configuration used for local development."""


### PR DESCRIPTION
Closes #69 

If `LD_RELAY_EVENTS_URL` or `LD_RELAY_STREAM_URL` is set use that value, otherwise it defaults to `base_uri`.