### PR TITLE
Configure artificial delay to showcase metrics

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3,7 +3,6 @@ import logging
 import boto3
 import botocore
 import time
-import random
 
 import ldclient
 from flask import (Blueprint, current_app, flash, redirect, render_template,
@@ -13,7 +12,7 @@ from werkzeug.urls import url_parse
 
 from app.factory import CACHE_TIMEOUT, CachingDisabled, cache, db
 from app.models import User, Plan
-
+from app.util import newServerFunctionality
 
 core = Blueprint('core', __name__)
 
@@ -40,13 +39,12 @@ def index():
         False)
     current_app.logger.info(trial_duration)
 
-    min_load_delay = 1
-    max_load_delay = 3
     start_time = time.time()
+    
+    # New server functionality testing
+    newServerFunctionality(trial_duration.value)
 
-    if trial_duration.value == '30':
-        time.sleep(random.randint(min_load_delay,max_load_delay))
-
+    # Calculate the server processing time based on flag evaluation
     end_time = time.time() - start_time
     data_export = {
         'flag': flag_name,

--- a/app/routes.py
+++ b/app/routes.py
@@ -37,7 +37,6 @@ def index():
         flag_name,
         user,
         False)
-    current_app.logger.info(trial_duration)
 
     start_time = time.time()
     

--- a/app/routes.py
+++ b/app/routes.py
@@ -33,29 +33,31 @@ def index():
     user = current_user.get_ld_user()
     session['ld_user'] = user
 
-    flag_name = 'longer-trial-duration'
-    longer_trial_duration = ldclient.get().variation_detail(
+    flag_name = 'trial-duration'
+    trial_duration = ldclient.get().variation_detail(
         flag_name,
         user,
         False)
+    current_app.logger.info(trial_duration)
 
+    min_load_delay = 1
+    max_load_delay = 3
     start_time = time.time()
-    if longer_trial_duration.value: # experimentation group
-        trial_duration = 30
-        time.sleep(random.randint(1,3))
-    else: # control group
-        trial_duration = 14
+
+    if trial_duration.value == '30':
+        time.sleep(random.randint(min_load_delay,max_load_delay))
+
     end_time = time.time() - start_time
     data_export = {
         'flag': flag_name,
-        'variation': longer_trial_duration.variation_index,
+        'variation': trial_duration.variation_index,
         'time': end_time,
     }
     ldclient.get().track('trial-rendering', user, data_export)
     
-    session['trial_duration'] = trial_duration
+    session['trial_duration'] = trial_duration.value
 
-    return render_template('home.html', trial_duration=trial_duration)
+    return render_template('home.html', trial_duration=trial_duration.value)
 
 @core.route('/dashboard')
 @login_required

--- a/app/routes.py
+++ b/app/routes.py
@@ -12,7 +12,7 @@ from werkzeug.urls import url_parse
 
 from app.factory import CACHE_TIMEOUT, CachingDisabled, cache, db
 from app.models import User, Plan
-from app.util import newServerFunctionality
+from app.util import artifical_delay
 
 core = Blueprint('core', __name__)
 
@@ -40,8 +40,7 @@ def index():
 
     start_time = time.time()
     
-    # New server functionality testing
-    newServerFunctionality(trial_duration.value)
+    artifical_delay(trial_duration.value)
 
     # Calculate the server processing time based on flag evaluation
     end_time = time.time() - start_time

--- a/app/util.py
+++ b/app/util.py
@@ -24,13 +24,14 @@ def getLdMachineUser(request=None):
     logging.debug(user)
     return user
 
-def newServerFunctionality(duration):
+def artifical_delay(duration):
     # Delays are in seconds
-    min_load_delay = 1
-    max_load_delay = 3
+    MIN_LOAD_DELAY = 1
+    MAX_LOAD_DELAY = 3
+    LOAD_DELAY_TRIGGER = 30
 
     # multi-variate flag is a string, so doing string comparison
-    if duration == '30':
-        time.sleep(random.randint(min_load_delay,max_load_delay))
+    if duration == LOAD_DELAY_TRIGGER:
+        time.sleep(random.randint(MIN_LOAD_DELAY,MAX_LOAD_DELAY))
     
     return 

--- a/app/util.py
+++ b/app/util.py
@@ -3,6 +3,8 @@ Utility Functions
 """
 import socket
 import logging
+import random
+import time
 
 def getLdMachineUser(request=None):
     """
@@ -21,3 +23,14 @@ def getLdMachineUser(request=None):
     }
     logging.debug(user)
     return user
+
+def newServerFunctionality(duration):
+    # Delays are in seconds
+    min_load_delay = 1
+    max_load_delay = 3
+
+    # multi-variate flag is a string, so doing string comparison
+    if duration == '30':
+        time.sleep(random.randint(min_load_delay,max_load_delay))
+    
+    return 


### PR DESCRIPTION
Enables enriched data export metrics by tracking how long server rendering takes.