### PR TITLE
ops: Refactor docker-compose nginx config

### DIFF
--- a/app/cli/templates/docker-compose.prod.jinja
+++ b/app/cli/templates/docker-compose.prod.jinja
@@ -37,18 +37,3 @@ services:
     image: redis:alpine
     ports:
       - "6379:6379"
-
-  web:
-    image: nginx:alpine
-    volumes:
-      - ./etc/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - /etc/letsencrypt:/etc/letsencrypt
-    ports:
-      - "80:80"
-      - "443:443"
-    depends_on:
-      - db
-      - cache
-      {% for env in envs %}
-      - {{ env.hostname }}
-      {% endfor %}

--- a/app/cli/templates/nginx.conf.jinja
+++ b/app/cli/templates/nginx.conf.jinja
@@ -1,4 +1,4 @@
-user  nginx;
+user  www-data;
 worker_processes  1;
 
 error_log  /var/log/nginx/error.log warn;
@@ -44,7 +44,7 @@ http {
         ssl_certificate_key /etc/letsencrypt/live/{{ domain }}/privkey.pem;
 
         location / {
-            proxy_pass http://{{ env.hostname }}:{{ env.port }};
+            proxy_pass http://127.0.0.1:{{ env.port }};
 			proxy_set_header Host $host;
 			proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -54,7 +54,7 @@ http {
 
     server {
         listen 80;
-        server_name *.ldsolutions.org;
+        server_name *.{{ domain }};
         location / {
             return 301 https://$host$request_uri;
         }
@@ -62,7 +62,7 @@ http {
 
     server {
         listen 443 ssl;
-        server_name *.ldsolutions.org;
+        server_name *.{{ domain }};
 
         ssl_certificate /etc/letsencrypt/live/{{ domain }}/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/{{ domain }}/privkey.pem;


### PR DESCRIPTION
Switch to using Nginx on-host instead of within docker. This makes
reloading faster, as well as making it much easier to use letsencrypt
with a wildcard certificate and automatic renewal.