### PR TITLE
Subdomain dispatcher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ jobs:
           name: Deploy to Production
           command: |
             . venv/bin/activate
+            make generate
             ./scripts/deploy.sh
   simulate:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,6 @@ jobs:
           name: Deploy to Staging
           command: |
             . venv/bin/activate
-            make generate-staging
             ./scripts/deploy_staging.sh
   deploy:
     docker:
@@ -140,7 +139,6 @@ jobs:
           name: Deploy to Production
           command: |
             . venv/bin/activate
-            make generate
             ./scripts/deploy.sh
   simulate:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,6 @@ jobs:
       - run:
           name: Test Production Stack
           command: |
-            pip install j2cli==0.3.10
             make generate
             docker-compose -f docker-compose.prod.yml up -d
       - run:
@@ -112,7 +111,6 @@ jobs:
           name: Deploy to Staging
           command: |
             . venv/bin/activate
-            pip install j2cli==0.3.10
             make generate
             ./scripts/deploy_staging.sh
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,8 @@ jobs:
       - run:
           name: Test Production Stack
           command: |
+            pip install j2cli==0.3.10
             make generate
-            mkdir -p etc/nginx
-            mv nginx.conf etc/nginx
             docker-compose -f docker-compose.prod.yml up -d
       - run:
           name: Debug Docker
@@ -113,6 +112,8 @@ jobs:
           name: Deploy to Staging
           command: |
             . venv/bin/activate
+            pip install j2cli==0.3.10
+            make generate
             ./scripts/deploy_staging.sh
   deploy:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Production Dockerfile for SupportService
 FROM python:3.6-alpine
 
-RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev bash git libffi-dev make postgresql-client
+RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev bash git libffi-dev make
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Production Dockerfile for SupportService
 FROM python:3.6-alpine
 
-RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev bash git libffi-dev make
+RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev bash git libffi-dev make postgresql-client
 
 WORKDIR /usr/src/app
 
@@ -12,4 +12,3 @@ RUN pip install -r requirements.txt
 COPY . .
 
 RUN pip install --upgrade -e .
-

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,5 +5,8 @@ RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev bash git libff
 
 WORKDIR /usr/src/app
 
+COPY requirements.txt .
+COPY setup.py .
+
 RUN pip install -r requirements.txt
 RUN pip install --upgrade -e .

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,6 @@ generate:
 	export FLASK_APP="app.factory:create_app('production')" && \
 	flask generate
 
-generate-staging:
-	export FLASK_APP="app.factory:create_app('staging')" && \
-	flask generate
-
 .PHONY: dev-container
 dev-container:
 	docker build -f Dockerfile.dev -t supportservice:latest .

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,16 @@ dev:
 	pip3 install -r dev-requirements.txt
 	pip3 install -e .
 
+# Not using flask run due to socket error for local debugging and reloading
+# https://stackoverflow.com/questions/53522052/flask-app-valueerror-signal-only-works-in-main-thread
 run:
-	export FLASK_APP="app.factory:create_app()" && \
+	export FLASK_APP="app.factory:SubdomainDispatcher('localhost','default')" &&\
 	export FLASK_DEBUG=true && \
 	export FLASK_ENV=development && \
-	flask run --host=0.0.0.0
+	python3 app/factory.py --host=localhost
 
 test:
-	set -e && coverage run tests/main.py
+	TESTING=True set -e && coverage run tests/main.py
 
 generate:
 	export FLASK_APP="app.factory:create_app('production')" && \
@@ -31,3 +33,7 @@ generate:
 generate-staging:
 	export FLASK_APP="app.factory:create_app('staging')" && \
 	flask generate
+
+.PHONY: dev-container
+dev-container:
+	docker build -f Dockerfile.dev -t supportservice:latest .

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ test:
 
 generate:
 	j2 app/cli/templates/docker-compose.prod.jinja > docker-compose.prod.yml
-	cat docker-compose.prod.yml
 
 .PHONY: dev-container
 dev-container:

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ test:
 	set -e && TESTING=true coverage run tests/main.py
 
 generate:
-	export FLASK_APP="app.factory:create_app('production')" && \
-	flask generate
+	j2 app/cli/templates/docker-compose.prod.jinja > docker-compose.prod.yml
+	cat docker-compose.prod.yml
 
 .PHONY: dev-container
 dev-container:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ run:
 	python3 app/factory.py --host=localhost
 
 test:
-	TESTING=True set -e && coverage run tests/main.py
+	set -e && TESTING=true coverage run tests/main.py
 
 generate:
 	export FLASK_APP="app.factory:create_app('production')" && \

--- a/app/cli/templates/docker-compose.prod.jinja
+++ b/app/cli/templates/docker-compose.prod.jinja
@@ -1,11 +1,10 @@
 version: '3'
 services:
-  {% for env in envs %}
-  {{ env.hostname }}:
-    hostname: {{ env.hostname }}
+  supportservice:
+    hostname: supportservice
     image: levlaz/supportservice:{{ circle_sha1 }}
     environment:
-      - FLASK_APP=app.factory:create_app('production')
+	    - FLASK_APP="app.factory:SubdomainDispatcher('ldsolutions.org','default')" &&\
       - DATABASE_URL=postgresql://supportService:supportService@db/supportService
       - FLASK_ENV=production
       - LD_CLIENT_KEY={{ env.api_key }}
@@ -16,12 +15,11 @@ services:
       - AWS_ACCOUNT_ID={{ AWS_ACCOUNT_ID }}
       - AWS_QUICKSIGHT_DASHBOARD_ID={{ AWS_QUICKSIGHT_DASHBOARD_ID }}
     ports:
-      - "{{ env.port }}:{{ env.port }}"
-    command: ["./scripts/start.sh", "{{ env.port }}"]
+      - "80:80"
+    command: ["./scripts/start.sh", "80"]
     depends_on:
       - db
       - cache
-  {% endfor %}
 
   db:
     image: postgres:11-alpine

--- a/app/cli/templates/docker-compose.prod.jinja
+++ b/app/cli/templates/docker-compose.prod.jinja
@@ -2,21 +2,20 @@ version: '3'
 services:
   supportservice:
     hostname: supportservice
-    image: levlaz/supportservice:{{ circle_sha1 }}
+    image: levlaz/supportservice:{{ env("CIRCLE_SHA1") }}
     environment:
-	    - FLASK_APP="app.factory:SubdomainDispatcher('ldsolutions.org','default')" &&\
+      - FLASK_DOMAIN="staging.ldsolutions.org"
       - DATABASE_URL=postgresql://supportService:supportService@db/supportService
       - FLASK_ENV=production
-      - LD_CLIENT_KEY={{ env.api_key }}
-      - LD_FRONTEND_KEY={{ env.client_id }}
+      - LD_API_KEY={{ env("LD_API_KEY") }}
       - REDIS_HOST=cache
-      - AWS_QUICKSIGHT_ACCESS_KEY_ID={{ AWS_QUICKSIGHT_ACCESS_KEY_ID }}
-      - AWS_QUICKSIGHT_SECRET_ACCESS_KEY_ID={{ AWS_QUICKSIGHT_SECRET_ACCESS_KEY_ID }}
-      - AWS_ACCOUNT_ID={{ AWS_ACCOUNT_ID }}
-      - AWS_QUICKSIGHT_DASHBOARD_ID={{ AWS_QUICKSIGHT_DASHBOARD_ID }}
+      - AWS_QUICKSIGHT_ACCESS_KEY_ID={{ env("AWS_QUICKSIGHT_ACCESS_KEY_ID") }}
+      - AWS_QUICKSIGHT_SECRET_ACCESS_KEY_ID={{ env("AWS_QUICKSIGHT_SECRET_ACCESS_KEY_ID") }}
+      - AWS_ACCOUNT_ID={{ env("AWS_ACCOUNT_ID") }}
+      - AWS_QUICKSIGHT_DASHBOARD_ID={{ env("AWS_QUICKSIGHT_DASHBOARD_ID") }}
     ports:
-      - "80:80"
-    command: ["./scripts/start.sh", "80"]
+      - "8001:8001"
+    command: ["./scripts/start.sh", "8001"]
     depends_on:
       - db
       - cache

--- a/app/cli/templates/docker-compose.prod.jinja
+++ b/app/cli/templates/docker-compose.prod.jinja
@@ -4,6 +4,7 @@ services:
     hostname: supportservice
     image: levlaz/supportservice:{{ env("CIRCLE_SHA1") }}
     environment:
+      - FLASK_APP=app.factory:create_app('12345','12345','production')
       - DATABASE_URL=postgresql://supportService:supportService@db/supportService
       - FLASK_ENV=production
       - LD_API_KEY={{ env("LD_API_KEY") }}

--- a/app/cli/templates/docker-compose.prod.jinja
+++ b/app/cli/templates/docker-compose.prod.jinja
@@ -4,7 +4,6 @@ services:
     hostname: supportservice
     image: levlaz/supportservice:{{ env("CIRCLE_SHA1") }}
     environment:
-      - FLASK_DOMAIN="staging.ldsolutions.org"
       - DATABASE_URL=postgresql://supportService:supportService@db/supportService
       - FLASK_ENV=production
       - LD_API_KEY={{ env("LD_API_KEY") }}

--- a/app/config.py
+++ b/app/config.py
@@ -67,7 +67,6 @@ class DevelopmentConfig(Config):
 
     @staticmethod
     def init_app(app):
-        print(app.config)
         # define and set required env vars
         LD_CLIENT_KEY = env_var("LD_CLIENT_KEY", app.config['LD_CLIENT_KEY'], required=True)
         LD_FRONTEND_KEY = env_var("LD_FRONTEND_KEY", app.config['LD_FRONTEND_KEY'], required=True)
@@ -88,7 +87,7 @@ class DevelopmentConfig(Config):
         Config.init_app(app)
 
         with app.app_context():
-            from app.factory import db
+            from app.db import db
             from app.models import User
             from app.models import Plan
 
@@ -128,7 +127,7 @@ class TestingConfig(Config):
         Config.init_app(app)
 
         with app.app_context():
-            from app.factory import db
+            from app.db import db
             from app.models import User
 
             db.init_app(app)
@@ -147,7 +146,7 @@ class StagingConfig(Config):
         Config.init_app(app)
 
         with app.app_context():
-            from app.factory import db
+            from app.db import db
             from app.models import User
             from app.models import Plan
 
@@ -163,7 +162,7 @@ class ProductionConfig(Config):
         Config.init_app(app)
 
         with app.app_context():
-            from app.factory import db
+            from app.db import db
             from app.models import User
             from app.models import Plan
 

--- a/app/config.py
+++ b/app/config.py
@@ -6,7 +6,6 @@ import sys
 import ldclient
 from ldclient import Config as LdConfig
 
-
 log = logging.getLogger()
 
 
@@ -14,15 +13,15 @@ def env_var(key, default=None, required=False):
     """
     Helper function to parse environment variables.
     """
-    if required:
+    if default is not None:
+        var = os.environ.get(key, default)
+    elif required:
         try:
             var = os.environ[key]
         except KeyError:
             log.error("ERROR: Required Environment Variable {0} is not set.".format(key))
         if len(os.environ[key]) == 0:
             log.error("ERROR: Required Environment Variable {0} is empty".format(key))
-    else:
-        var = os.environ.get(key, default)
 
     try:
         return var
@@ -42,7 +41,9 @@ class Config(object):
         )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     LOG_TO_STDOUT = os.environ.get('LOG_TO_STDOUT')
-    CACHE_REDIS_HOST = os.environ.get('REDIS_HOST') or 'cache'
+    REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
+    CACHE_REDIS_HOST = REDIS_HOST
+    REDIS_URL = os.environ.get('REDIS_URL')
     CACHE_CONFIG = {'CACHE_TYPE': 'simple'}
 
     AWS_QUICKSIGHT_ACCESS_KEY_ID = os.environ.get('AWS_QUICKSIGHT_ACCESS_KEY_ID')
@@ -51,23 +52,6 @@ class Config(object):
     AWS_QUICKSIGHT_DASHBOARD_ID = os.environ.get('AWS_QUICKSIGHT_DASHBOARD_ID')
     AWS_QUICKSIGHT_SESSION_LIFE = 100
     AWS_QUICKSIGHT_REGION = "us-west-2"
-
-    # define and set required env vars
-    LD_CLIENT_KEY = env_var("LD_CLIENT_KEY", required=True)
-    LD_FRONTEND_KEY = env_var("LD_FRONTEND_KEY", required=True)
-
-    # LaunchDarkly Config
-    # If $LD_RELAY_URL is set, client will be pointed to a relay instance.
-    if "LD_RELAY_URL" in os.environ:
-        config = LdConfig(
-            sdk_key = LD_CLIENT_KEY,
-            base_uri = os.environ.get("LD_RELAY_URL"),
-            events_uri = os.environ.get("LD_RELAY_EVENTS_URL", base_uri),
-            stream_uri = os.environ.get("LD_RELAY_STREAM_URL", base_uri)
-        )
-        ldclient.set_config(config)
-    else:
-        ldclient.set_sdk_key(LD_CLIENT_KEY)
 
     root = logging.getLogger()
     root.setLevel(logging.INFO)
@@ -83,6 +67,24 @@ class DevelopmentConfig(Config):
 
     @staticmethod
     def init_app(app):
+        print(app.config)
+        # define and set required env vars
+        LD_CLIENT_KEY = env_var("LD_CLIENT_KEY", app.config['LD_CLIENT_KEY'], required=True)
+        LD_FRONTEND_KEY = env_var("LD_FRONTEND_KEY", app.config['LD_FRONTEND_KEY'], required=True)
+
+        # LaunchDarkly Config
+        # If $LD_RELAY_URL is set, client will be pointed to a relay instance.
+        if "LD_RELAY_URL" in os.environ:
+            config = LdConfig(
+                sdk_key = app.config.LD_CLIENT_KEY,
+                base_uri = os.environ.get("LD_RELAY_URL"),
+                events_uri = os.environ.get("LD_RELAY_EVENTS_URL", base_uri),
+                stream_uri = os.environ.get("LD_RELAY_STREAM_URL", base_uri)
+            )
+            ldclient.set_config(config)
+        else:
+            ldclient.set_sdk_key(LD_CLIENT_KEY)
+
         Config.init_app(app)
 
         with app.app_context():
@@ -119,6 +121,7 @@ class TestingConfig(Config):
     """Configuration used for testing and CI."""
     TESTING = True
     DEBUG = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///supportservice.db"
 
     @staticmethod
     def init_app(app):
@@ -138,7 +141,6 @@ class TestingConfig(Config):
 class StagingConfig(Config):
     """Configuration used for production environments."""
     CACHE_CONFIG = {'CACHE_TYPE': 'redis'}
-    APP_DOMAIN = "staging.ldsolutions.org"
 
     @staticmethod
     def init_app(app):
@@ -155,8 +157,7 @@ class StagingConfig(Config):
 class ProductionConfig(Config):
     """Configuration used for production environments."""
     CACHE_CONFIG = {'CACHE_TYPE': 'redis'}
-    APP_DOMAIN = "ldsolutions.org"
-    
+
     @staticmethod
     def init_app(app):
         Config.init_app(app)

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,3 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()

--- a/app/factory.py
+++ b/app/factory.py
@@ -49,12 +49,11 @@ class SubdomainDispatcher(object):
             self.rclient = redis.Redis(host=os.environ.get('REDIS_HOST'))
             self.project = self.ld.get_project(PROJECT_NAME)
             project_pick = pickle.dumps(self.project)
-            self.rclient.set("support-service", project_pick)
+            self.rclient.set(PROJECT_NAME, project_pick)
         else:
             import fakeredis
             self.rclient = fakeredis.FakeStrictRedis()
             self.project = {}
-
 
 
     def get_application(self, host):
@@ -136,7 +135,7 @@ class SubdomainDispatcher(object):
         return app
 
     def make_app(self, ld, subdomain, config_name):
-        project = pickle.loads(self.rclient.get('support-service'))
+        project = pickle.loads(self.rclient.get(PROJECT_NAME))
         for env in project.environments:
             if env.key == subdomain:
                 return self.create_app(subdomain, env, config_name=config_name)
@@ -146,7 +145,7 @@ class SubdomainDispatcher(object):
     def build_environments(self, app, subdomain, env):
         if os.environ.get('TESTING') is None or os.environ.get('TESTING') == False:
             app.redis_client = FlaskRedis(app)
-            project = self.rclient.get("support-service")
+            project = self.rclient.get(PROJECT_NAME)
             ld_project = pickle.loads(project)
             environments = ld_project.environments
             for env in environments:

--- a/app/factory.py
+++ b/app/factory.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from threading import Lock
+import pickle
 
 import ldclient
 import redis
@@ -21,9 +22,7 @@ from app.cli.generators import ConfigGenerator
 from app.models import User
 from app.db import db
 
-import json
-import pickle
-import datetime
+
 
 migrate = Migrate()
 bootstrap =  Bootstrap()

--- a/app/factory.py
+++ b/app/factory.py
@@ -76,7 +76,7 @@ class SubdomainDispatcher(object):
         return app(environ, start_response)
 
 
-def create_app(subdomain, env, config_name):
+def create_app(env_id, env_api_key, config_name):
     """Flask application factory.
 
     :param config_name: Flask Configuration
@@ -86,7 +86,7 @@ def create_app(subdomain, env, config_name):
     :returns: a flask application
     """
     app = Flask(__name__)
-    app = build_environments(subdomain, env, app)
+    app = build_environment(env_id, env_api_key, app)
     app.config.from_object(config[config_name])
     config[config_name].init_app(app)
 
@@ -136,20 +136,20 @@ def make_app(ld, rclient, subdomain, project, config_name):
     project = pickle.loads(rclient.get(PROJECT_NAME))
     for env in project.environments:
         if env.key == subdomain:
-            return create_app(subdomain, env, config_name=config_name)
+            return create_app(env.id, env.api_key, config_name)
 
     return NotFound()
 
-def build_environments(subdomain, env, app):
+def build_environment(env_id, env_api_key, app):
     if os.environ.get('TESTING') is None or os.environ.get('TESTING') == False:
         app.redis_client = FlaskRedis(app)
-        logging.info(env.api_key)
-        logging.info(env.id)
-        app.config['LD_CLIENT_KEY'] = env.api_key
-        app.config['LD_FRONTEND_KEY'] = env.id
+        logging.info(env_api_key)
+        logging.info(env_id)
+        app.config['LD_CLIENT_KEY'] = env_api_key
+        app.config['LD_FRONTEND_KEY'] = env_id
     else:
-        app.config['LD_CLIENT_KEY'] = env['LD_CLIENT_KEY']
-        app.config['LD_FRONTEND_KEY'] = env['LD_FRONTEND_KEY']
+        app.config['LD_CLIENT_KEY'] = env_id['LD_CLIENT_KEY']
+        app.config['LD_FRONTEND_KEY'] = env_api_key['LD_FRONTEND_KEY']
 
     return app
 

--- a/app/factory.py
+++ b/app/factory.py
@@ -1,20 +1,29 @@
 import logging
 import os
+from threading import Lock
 
 import ldclient
+import redis
+
 from flask import Flask
 from flask_bootstrap import Bootstrap
 from flask_caching import Cache
 from flask_login import LoginManager
 from flask_migrate import Migrate
-from flask_sqlalchemy import SQLAlchemy
+from werkzeug.serving import run_simple
+from werkzeug.exceptions import NotFound
+from flask_redis import FlaskRedis
 
 from app.config import config
 from app.util import getLdMachineUser
-from app.cli.ld import LaunchDarklyApi
+from app.ld import LaunchDarklyApi
 from app.cli.generators import ConfigGenerator
+from app.models import User, db
 
-db = SQLAlchemy()
+import json
+import pickle
+import datetime
+
 migrate = Migrate()
 bootstrap =  Bootstrap()
 login = LoginManager()
@@ -22,77 +31,161 @@ cache = Cache()
 
 # Operational Feature Flags
 CACHE_TIMEOUT = lambda : ldclient.get().variation('cache-timeout', getLdMachineUser(), 50)
+PROJECT_NAME = 'support-service'
 
 class CachingDisabled:
     def __call__(self):
         return ldclient.get().variation('disable-caching', getLdMachineUser(), True)
 
+class SubdomainDispatcher(object):
 
-def create_app(config_name = 'default'):
-    """Flask application factory.
+    def __init__(self, domain='', debug=False, config_name='default'):
+        self.domain = domain
+        self.lock = Lock()
+        self.instances = {}
+        self.ld = LaunchDarklyApi(os.environ.get('LD_API_KEY'), domain)
+        self.config_name= config_name
+        if os.environ.get('TESTING') is None or os.environ.get('TESTING') == False:
+            self.rclient = redis.Redis(host=os.environ.get('REDIS_HOST'))
+            self.project = self.ld.get_project(PROJECT_NAME)
+            project_pick = pickle.dumps(self.project)
+            self.rclient.set("support-service", project_pick)
+        else:
+            import fakeredis
+            self.rclient = fakeredis.FakeStrictRedis()
+            self.project = {}
 
-    :param config_name: Flask Configuration
 
-    :type config_name: app.config class
 
-    :returns: a flask application
+    def get_application(self, host):
+        logging.info(self.domain)
+        host = host.split(':')[0]
+        assert host.endswith(self.domain), 'Configuration error'
+        subdomain = host[:-len(self.domain)].rstrip('.')
+
+        with self.lock:
+            app = self.instances.get(subdomain)
+            if app is None:
+                app = self.make_app(self.ld, subdomain, self.config_name)
+                #app = self.create_app(self.ld, subdomain)
+                self.instances[subdomain] = app
+            return app
+
+    def __call__(self, environ, start_response):
+        app = self.get_application(environ['HTTP_HOST'])
+        @login.user_loader
+        def load_user(id):
+            return User.query.get(id)
+        return app(environ, start_response)
+
+    def create_app(self, subdomain, env, config_name):
+        """Flask application factory.
+
+        :param config_name: Flask Configuration
+
+        :type config_name: app.config class
+
+        :returns: a flask application
+        """
+        app = Flask(__name__)
+        app = self.build_environments(app, subdomain, env)
+        app.config.from_object(config[config_name])
+        config[config_name].init_app(app)
+
+        app.project = self.project
+        #app.ld = ld
+        app.logger.info("APP VERSION: " + app.config['VERSION'])
+
+        bootstrap.init_app(app)
+        cache.init_app(app, config=app.config['CACHE_CONFIG'])
+        login.init_app(app)
+
+        login.login_view = 'core.login'
+        from app.models import AnonymousUser
+        login.anonymous_user = AnonymousUser
+        migrate.init_app(app, db)
+
+        from app.routes import core
+        app.register_blueprint(core)
+
+        @app.before_request
+        def setLoggingLevel():
+            """Set Logging Level Based on Feature Flag
+
+            This uses LaunchDarkly to update the logging level dynamically.
+            Before each request runs, we check the current logging level and
+            it does not match, we update it to the new value.
+
+            Logging levels are integer values based on the standard Logging library
+            in python: https://docs.python.org/3/library/logging.html#logging-levels
+
+            This is an operational feature flag.
+            """
+            from flask import request
+            logLevel = ldclient.get().variation("set-logging-level", getLdMachineUser(request), logging.INFO)
+
+            app.logger.info("Log level is {0}".format(logLevel))
+
+            # set app
+            app.logger.setLevel(logLevel)
+            # set werkzeug
+            logging.getLogger('werkzeug').setLevel(logLevel)
+            # set root
+            logging.getLogger().setLevel(logLevel)
+
+        return app
+
+    def make_app(self, ld, subdomain, config_name):
+        project = pickle.loads(self.rclient.get('support-service'))
+        for env in project.environments:
+            if env.key == subdomain:
+                return self.create_app(subdomain, env, config_name=config_name)
+
+        return NotFound()
+
+    def build_environments(self, app, subdomain, env):
+        if os.environ.get('TESTING') is None or os.environ.get('TESTING') == False:
+            app.redis_client = FlaskRedis(app)
+            project = self.rclient.get("support-service")
+            ld_project = pickle.loads(project)
+            environments = ld_project.environments
+            for env in environments:
+                if env.key == subdomain:
+                    current_env = env
+                    break
+            app.config['LD_CLIENT_KEY'] = current_env.api_key
+            app.config['LD_FRONTEND_KEY'] = current_env.id
+        else:
+            app.config['LD_CLIENT_KEY'] = env['LD_CLIENT_KEY']
+            app.config['LD_FRONTEND_KEY'] = env['LD_FRONTEND_KEY']
+
+        return app
+
+def rundevserver(host='0.0.0.0', port=5000, domain='localhost', **options):
     """
-    app = Flask(__name__)
-    app.config.from_object(config[config_name])
+    Modified from `flask.Flask.run`
+    Runs the application on a local development server.
+    :param host: the hostname to listen on. Set this to ``'0.0.0.0'`` to
+                 have the server available externally as well. Defaults to
+                 ``'127.0.0.1'``.
+    :param port: the port of the webserver. Defaults to ``5000``
+    :param domain: used to determine the subdomain
+    :param options: the options to be forwarded to the underlying
+                    Werkzeug server.  See
+                    :func:`werkzeug.serving.run_simple` for more
+                    information.
+    """
+    from werkzeug.serving import run_simple
 
-    config[config_name].init_app(app)
+    options.setdefault('use_reloader', True)
+    options.setdefault('use_debugger', True)
 
-    app.logger.info("APP VERSION: " + app.config['VERSION'])
+    app = SubdomainDispatcher(domain=domain)
 
-    bootstrap.init_app(app)
-    cache.init_app(app, config=app.config['CACHE_CONFIG'])
-    login.init_app(app)
-    login.login_view = 'core.login'
-    from app.models import AnonymousUser
-    login.anonymous_user = AnonymousUser
-    migrate.init_app(app, db)
+    run_simple(host, port, app, **options)
 
-    from app.routes import core
-    app.register_blueprint(core)
 
-    @app.before_request
-    def setLoggingLevel():
-        """Set Logging Level Based on Feature Flag
+application = SubdomainDispatcher(domain=os.environ.get('FLASK_DOMAIN', 'localhost'), config_name=os.environ.get('SS_CONFIG', 'default'))
 
-        This uses LaunchDarkly to update the logging level dynamically.
-        Before each request runs, we check the current logging level and
-        it does not match, we update it to the new value.
-
-        Logging levels are integer values based on the standard Logging library
-        in python: https://docs.python.org/3/library/logging.html#logging-levels
-
-        This is an operational feature flag.
-        """
-        from flask import request
-        logLevel = ldclient.get().variation("set-logging-level", getLdMachineUser(request), logging.INFO)
-
-        app.logger.info("Log level is {0}".format(logLevel))
-
-        # set app
-        app.logger.setLevel(logLevel)
-        # set werkzeug
-        logging.getLogger('werkzeug').setLevel(logLevel)
-        # set root
-        logging.getLogger().setLevel(logLevel)
-
-    @app.cli.command()
-    def generate():
-        """
-        Generate production configuration files for nginx and docker-compose.
-        """
-        l = LaunchDarklyApi(os.environ.get('LD_API_KEY'), app.config["APP_DOMAIN"])
-        c = ConfigGenerator()
-
-        envs = l.getEnvironments('support-service')
-
-        c.generate_prod_config(envs)
-        c.generate_nginx_config(app.config['APP_DOMAIN'], envs)
-
-    app.cli.add_command(generate)
-
-    return app
+if __name__ == '__main__':
+    rundevserver(host="0.0.0.0")

--- a/app/factory.py
+++ b/app/factory.py
@@ -143,13 +143,11 @@ def make_app(ld, rclient, subdomain, project, config_name):
 def build_environment(env_id, env_api_key, app):
     if os.environ.get('TESTING') is None or os.environ.get('TESTING') == False:
         app.redis_client = FlaskRedis(app)
-        logging.info(env_api_key)
-        logging.info(env_id)
-        app.config['LD_CLIENT_KEY'] = env_api_key
-        app.config['LD_FRONTEND_KEY'] = env_id
-    else:
-        app.config['LD_CLIENT_KEY'] = env_id['LD_CLIENT_KEY']
-        app.config['LD_FRONTEND_KEY'] = env_api_key['LD_FRONTEND_KEY']
+
+    logging.info(env_api_key)
+    logging.info(env_id)
+    app.config['LD_CLIENT_KEY'] = env_api_key
+    app.config['LD_FRONTEND_KEY'] = env_id
 
     return app
 

--- a/app/factory.py
+++ b/app/factory.py
@@ -59,7 +59,6 @@ class SubdomainDispatcher(object):
     def get_application(self, host):
         logging.info(self.domain)
         host = host.split(':')[0]
-        assert host.endswith(self.domain), 'Configuration error'
         subdomain = host[:-len(self.domain)].rstrip('.')
 
         with self.lock:
@@ -185,6 +184,7 @@ def rundevserver(host='0.0.0.0', port=5000, domain='localhost', **options):
 
 
 application = SubdomainDispatcher(domain=os.environ.get('FLASK_DOMAIN', 'localhost'), config_name=os.environ.get('SS_CONFIG', 'default'))
+
 
 if __name__ == '__main__':
     rundevserver(host="0.0.0.0")

--- a/app/factory.py
+++ b/app/factory.py
@@ -86,7 +86,13 @@ def create_app(env_id, env_api_key, config_name):
     :returns: a flask application
     """
     app = Flask(__name__)
-    app = build_environment(env_id, env_api_key, app)
+    app = build_environment(app)
+    if env_api_key:
+        app.config['LD_CLIENT_KEY'] = env_api_key
+        logging.info(env_api_key)
+    if env_id:
+        app.config['LD_FRONTEND_KEY'] = env_id
+        logging.info(env_id)
     app.config.from_object(config[config_name])
     config[config_name].init_app(app)
 
@@ -140,14 +146,9 @@ def make_app(ld, rclient, subdomain, project, config_name):
 
     return NotFound()
 
-def build_environment(env_id, env_api_key, app):
+def build_environment(app):
     if os.environ.get('TESTING') is None or os.environ.get('TESTING') == False:
         app.redis_client = FlaskRedis(app)
-
-    logging.info(env_api_key)
-    logging.info(env_id)
-    app.config['LD_CLIENT_KEY'] = env_api_key
-    app.config['LD_FRONTEND_KEY'] = env_id
 
     return app
 

--- a/app/ld.py
+++ b/app/ld.py
@@ -12,27 +12,19 @@ import json
 class LaunchDarklyApi():
     """Wrapper for the LaunchDarkly API"""
 
-    def __init__(self, apiKey, domain):
+    def __init__(self, apiKey):
         """Instantiate a new LaunchDarklyApi instance.
 
         :param apiKey: API Access Key for LaunchDarkly
         :param domain: domain to use for generating hostnames
         """
         self.apiKey = apiKey
-        self.domain = domain
 
         # get new LD client
         configuration = launchdarkly_api.Configuration()
         configuration.api_key['Authorization'] = apiKey
         self.client = launchdarkly_api.ProjectsApi(
             launchdarkly_api.ApiClient(configuration))
-
-    def format_hostname(self, key):
-        """Returns formatted hostname for an environment.
-
-        :param key: environment key
-        """
-        return "{0}.{1}".format(key, self.domain)
 
     def get_environments(self, projectKey):
         """Returns List of Environments for a Project.
@@ -48,7 +40,6 @@ class LaunchDarklyApi():
         return resp
 
     def get_environment(self, environment_key):
-        #logging.info(project.environments)
         for env in project.environments:
             logging.info(env.name)
             if env.name == environment_key:

--- a/app/ld.py
+++ b/app/ld.py
@@ -26,26 +26,6 @@ class LaunchDarklyApi():
         self.client = launchdarkly_api.ProjectsApi(
             launchdarkly_api.ApiClient(configuration))
 
-    def get_environments(self, projectKey):
-        """Returns List of Environments for a Project.
-
-        Includes name, key, and mobile key.
-
-        :param projectKey: Key for project
-
-        :returns: Collection of Environments
-        """
-        resp = self.client.get_project(projectKey)
-
-        return resp
-
-    def get_environment(self, environment_key):
-        for env in project.environments:
-            logging.info(env.name)
-            if env.name == environment_key:
-                return env
-
-
     def get_project(self, project_key):
         resp = self.client.get_project(project_key)
 

--- a/app/ld.py
+++ b/app/ld.py
@@ -6,7 +6,8 @@ Note that the API SDK is generated using swagger. The entire library is
 stored in the lib/ directory since we do not currently publish this anywhere.
 """
 import launchdarkly_api
-
+import logging
+import json
 
 class LaunchDarklyApi():
     """Wrapper for the LaunchDarkly API"""
@@ -26,40 +27,35 @@ class LaunchDarklyApi():
         self.client = launchdarkly_api.ProjectsApi(
             launchdarkly_api.ApiClient(configuration))
 
-    def formatHostname(self, key):
+    def format_hostname(self, key):
         """Returns formatted hostname for an environment.
 
         :param key: environment key
         """
         return "{0}.{1}".format(key, self.domain)
 
-    def getEnvironments(self, projectKey):
+    def get_environments(self, projectKey):
         """Returns List of Environments for a Project.
 
-        Includes name, key, and mobile key, and formatted hostname.
+        Includes name, key, and mobile key.
 
         :param projectKey: Key for project
 
         :returns: Collection of Environments
         """
         resp = self.client.get_project(projectKey)
-        envs = []
-        port = 8000
 
-        for env in resp.environments:
-            port += 1
-            env = dict(
-                key=env.key,
-                api_key = env.api_key,
-                client_id = env.id,
-                hostname = self.formatHostname(env.key),
-                port = port
-            )
-            envs.append(env)
+        return resp
 
-        return envs
+    def get_environment(self, environment_key):
+        #logging.info(project.environments)
+        for env in project.environments:
+            logging.info(env.name)
+            if env.name == environment_key:
+                return env
 
-    def getEnvironment(self, projectKey, environmentKey):
-        resp = self.client.get_project(projectKey)
 
-        return resp.environments.get(projectKey, environmentKey)
+    def get_project(self, project_key):
+        resp = self.client.get_project(project_key)
+
+        return resp

--- a/app/models.py
+++ b/app/models.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 from faker import Faker
 from flask import current_app
-from flask_sqlalchemy import SQLAlchemy
 from flask_login import AnonymousUserMixin, UserMixin
 from werkzeug.security import check_password_hash, generate_password_hash
 from app.db import db

--- a/app/models.py
+++ b/app/models.py
@@ -3,13 +3,15 @@ import time
 import uuid
 from datetime import datetime
 
-from app.factory import db, login
+#from app.factory import db
 from faker import Faker
 from flask import current_app
+from flask_sqlalchemy import SQLAlchemy
 from flask_login import AnonymousUserMixin, UserMixin
 from werkzeug.security import check_password_hash, generate_password_hash
 
 fake = Faker()
+db = SQLAlchemy()
 
 class User(UserMixin, db.Model):
 
@@ -42,7 +44,6 @@ class User(UserMixin, db.Model):
     def get_email_hash(self):
         return hashlib.md5(self.email.encode()).hexdigest()
 
-
     def get_ld_user(self):
         app_version = current_app.config['VERSION']
         milliseconds = int(round(time.time() * 1000))
@@ -69,10 +70,6 @@ class User(UserMixin, db.Model):
     def get_random_ld_user(self):
         user = {'key': str(uuid.uuid1())}
         return user
-
-@login.user_loader
-def load_user(id):
-    return User.query.get(int(id))
 
 
 class AnonymousUser(AnonymousUserMixin):

--- a/app/models.py
+++ b/app/models.py
@@ -3,15 +3,14 @@ import time
 import uuid
 from datetime import datetime
 
-#from app.factory import db
 from faker import Faker
 from flask import current_app
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import AnonymousUserMixin, UserMixin
 from werkzeug.security import check_password_hash, generate_password_hash
+from app.db import db
 
 fake = Faker()
-db = SQLAlchemy()
 
 class User(UserMixin, db.Model):
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -11,7 +11,6 @@ from flask_login import current_user, login_required, login_user, logout_user
 from werkzeug.urls import url_parse
 
 from app.factory import CACHE_TIMEOUT, CachingDisabled, cache, db
-#from app.ld import get_environments
 from app.models import User, Plan
 from app.util import artifical_delay
 
@@ -281,7 +280,7 @@ def environments():
     webhook = ldclient.get().variation('environments-webhook', current_user.get_ld_user(), False)
     if webhook:
         try:
-            project = current_app.ld.get_environments("support-service")
+            project = current_app.ld.get_project("support-service")
             project_pick = pickle.dumps(project)
             current_app.redis_client.set("support-service", project_pick)
             return jsonify({'response': 200})

--- a/app/util.py
+++ b/app/util.py
@@ -33,5 +33,5 @@ def artifical_delay(duration):
     # multi-variate flag is a string, so doing string comparison
     if duration == LOAD_DELAY_TRIGGER:
         time.sleep(random.randint(MIN_LOAD_DELAY,MAX_LOAD_DELAY))
-    
-    return 
+
+    return

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ pylint
 unittest-xml-reporting
 codecov
 python-dotenv
+fakeredis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       - FLASK_DEBUG=true
       - REDIS_HOST=cache
       - REDIS_URL=redis://cache:6379/0
-      - SS_CONFIG=default
     volumes:
       - .:/usr/src/app
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,25 @@
 version: '3'
 services:
-  
+
   app:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    env_file: 
+    env_file:
       - .env
     environment:
-      - FLASK_APP=app.factory:create_app('development')
+      - FLASK_APP=app.factory:SubdomainDispatcher('localhost','default')
       - DATABASE_URL=postgresql://supportService:supportService@db/supportService
       - FLASK_ENV=development
+      - FLASK_DEBUG=true
       - REDIS_HOST=cache
+      - REDIS_URL=redis://cache:6379/0
+      - SS_CONFIG=default
     volumes:
       - .:/usr/src/app
     ports:
       - "5000:5000"
-    command: ["./scripts/start_dev.sh", "5000"]
+    command: ["python3", "app/factory.py", "--host=0.0.0.0"]
     depends_on:
       - db
       - cache
@@ -35,4 +38,3 @@ services:
     image: redis:alpine
     ports:
       - "6379:6379"
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,6 @@ launchdarkly-api==2.0.15
 
 # Runtime
 gunicorn==19.9.0
+
+# Docker-compose generator
+j2cli==0.3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ boto3==1.9.156
 # Database
 psycopg2-binary==2.8.2
 redis==3.2.1
+flask-redis==0.4.0
 
 # Vendor Dependencies
 ldclient-py==6.9.1

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-until bash -c "flask db current > /dev/null 2>&1"; do
+while ! nc -zv db 5432; do
     >&2 echo "Postgres is unavailable - sleeping"
     sleep 1
 done
 
 >&2 echo "Postgres is up, starting SupportService"
-flask db upgrade > /dev/null 2>&1
-gunicorn "app.factory:SubdomainDispatcher('ldsolutions.org','default')" -b 0.0.0.0:$1
+gunicorn "app.factory:application" -b 0.0.0.0:$1

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -6,4 +6,5 @@ while ! nc -zv db 5432; do
 done
 
 >&2 echo "Postgres is up, starting SupportService"
+flask db upgrade > /dev/null 2>&1
 gunicorn "app.factory:application" -b 0.0.0.0:$1

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,4 +7,4 @@ done
 
 >&2 echo "Postgres is up, starting SupportService"
 flask db upgrade > /dev/null 2>&1
-gunicorn "app.factory:create_app('production')" -b 0.0.0.0:$1
+gunicorn "app.factory:SubdomainDispatcher('ldsolutions.org','default')" -b 0.0.0.0:$1

--- a/scripts/start_dev.sh
+++ b/scripts/start_dev.sh
@@ -6,5 +6,4 @@ until bash -c "flask db current > /dev/null 2>&1"; do
 done
 
 >&2 echo "Postgres is up, starting SupportService"
-flask db upgrade > /dev/null 2>&1
-flask run -h 0.0.0.0 -p $1 --reload
+python3 app/factory.py --host=localhost

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'click',
         'click-log',
         'launchdarkly-api',
-        'boto3'
+        'boto3',
+        'j2cli'
     ]
 )

--- a/tests/model_base.py
+++ b/tests/model_base.py
@@ -4,11 +4,9 @@ from app.db import db
 
 class ModelBase(unittest.TestCase):
     def setUp(self):
-        env = {
-            'LD_CLIENT_KEY': '12345',
-            'LD_FRONTEND_KEY': '12345'
-        }
-        self.app = create_app('testing', env, config_name='testing')
+        env_id = '12345'
+        env_api_key = '12345'
+        self.app = create_app(env_id, env_api_key, config_name='testing')
         self.app_context = self.app.app_context()
         self.app_context.push()
         db.create_all()

--- a/tests/model_base.py
+++ b/tests/model_base.py
@@ -1,15 +1,14 @@
 import unittest
-from app.factory import SubdomainDispatcher
+from app.factory import create_app
 from app.db import db
 
 class ModelBase(unittest.TestCase):
     def setUp(self):
-        self.app = SubdomainDispatcher('localhost','default')
         env = {
             'LD_CLIENT_KEY': '12345',
             'LD_FRONTEND_KEY': '12345'
         }
-        self.app = self.app.create_app('testing', env, config_name='testing')
+        self.app = create_app('testing', env, config_name='testing')
         self.app_context = self.app.app_context()
         self.app_context.push()
         db.create_all()

--- a/tests/model_base.py
+++ b/tests/model_base.py
@@ -1,6 +1,6 @@
 import unittest
 from app.factory import SubdomainDispatcher
-from app.models import db
+from app.db import db
 
 class ModelBase(unittest.TestCase):
     def setUp(self):

--- a/tests/model_base.py
+++ b/tests/model_base.py
@@ -1,10 +1,15 @@
 import unittest
-from app.factory import create_app, db
-
+from app.factory import SubdomainDispatcher
+from app.models import db
 
 class ModelBase(unittest.TestCase):
     def setUp(self):
-        self.app = create_app('testing')
+        self.app = SubdomainDispatcher('localhost','default')
+        env = {
+            'LD_CLIENT_KEY': '12345',
+            'LD_FRONTEND_KEY': '12345'
+        }
+        self.app = self.app.create_app('testing', env, config_name='testing')
         self.app_context = self.app.app_context()
         self.app_context.push()
         db.create_all()

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -3,7 +3,7 @@ import unittest
 from flask import current_app
 
 from app.factory import SubdomainDispatcher
-from app.models import db
+from app.db import db
 
 
 class BasicTestCase(unittest.TestCase):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -2,12 +2,18 @@ import unittest
 
 from flask import current_app
 
-from app.factory import create_app, db
+from app.factory import SubdomainDispatcher
+from app.models import db
 
 
 class BasicTestCase(unittest.TestCase):
     def setUp(self):
-        self.app = create_app('testing')
+        self.app = SubdomainDispatcher('localhost','default')
+        env = {
+            'LD_CLIENT_KEY': '12345',
+            'LD_FRONTEND_KEY': '12345'
+        }
+        self.app = self.app.create_app('testing', env, config_name='testing')
         self.app_context = self.app.app_context()
         self.app_context.push()
         db.create_all()

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -2,18 +2,18 @@ import unittest
 
 from flask import current_app
 
-from app.factory import SubdomainDispatcher
+from app.factory import create_app
 from app.db import db
 
 
 class BasicTestCase(unittest.TestCase):
     def setUp(self):
-        self.app = SubdomainDispatcher('localhost','default')
+        #self.app = SubdomainDispatcher('localhost','default')
         env = {
             'LD_CLIENT_KEY': '12345',
             'LD_FRONTEND_KEY': '12345'
         }
-        self.app = self.app.create_app('testing', env, config_name='testing')
+        self.app = create_app('testing', env, config_name='testing')
         self.app_context = self.app.app_context()
         self.app_context.push()
         db.create_all()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,5 @@
-from app.models import User, Plan, db
+from app.models import User, Plan
+from app.db import db
 from model_base import ModelBase
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,4 @@
-from app.factory import db
-from app.models import User, Plan
+from app.models import User, Plan, db
 from model_base import ModelBase
 
 


### PR DESCRIPTION
Closes #75 

Previously every subdomain had a set of containers: web app, db, redis

This PR changes that logic so that there is only 3 containers total. The single flask app now performs subdomain dispatching based on LaunchDarkly environments. The environments are persisted into Redis.

Flask no longer performs the template generation logic. j2cli is now being used to create the docker-compose file.
