### PR TITLE
webdriver: Make max threads configurable

### DIFF
--- a/tests/webdriver/pom.xml
+++ b/tests/webdriver/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-server</artifactId>
-        <version>3.0.1</version>
+        <version>3.141.59</version>
     </dependency>
     <dependency>
         <groupId>com.github.javafaker</groupId>
@@ -37,6 +37,12 @@
         <artifactId>api-client</artifactId>
         <version>2.0.9</version>
         <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.launchdarkly</groupId>
+      <artifactId>launchdarkly-java-server-sdk</artifactId>
+      <version>4.8.0</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/tests/webdriver/src/main/java/webdriver/App.java
+++ b/tests/webdriver/src/main/java/webdriver/App.java
@@ -9,6 +9,7 @@ import com.launchdarkly.api.api.ProjectsApi;
 import com.launchdarkly.api.model.Project;
 import com.launchdarkly.api.model.Environment;
 import com.launchdarkly.api.Configuration;
+import com.launchdarkly.client.*;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -24,17 +25,19 @@ public class App
 {
     private static final Logger logger =
         LoggerFactory.getLogger(App.class.getName());
-    private static final int MAX_THREADS = 3;
     private static final String PROJECT_KEY = "support-service";
 
     public static void main( String[] args ) throws InterruptedException
     {
-        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(MAX_THREADS);
-
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         ApiKeyAuth Token = (ApiKeyAuth) defaultClient.getAuthentication("Token");
         Token.setApiKey(System.getenv("LD_API_KEY"));
         ProjectsApi apiInstance = new ProjectsApi();
+        LDClient ldClient = new LDClient(System.getenv("LD_CLIENT_KEY"));
+        LDUser user = new LDUser("any");
+        int maxThreads = ldClient.intVariation("max-selenium-threads", user, 1);
+
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(maxThreads);
 
         try {
             Project result = apiInstance.getProject(PROJECT_KEY);

--- a/tests/webdriver/src/main/java/webdriver/Simulator.java
+++ b/tests/webdriver/src/main/java/webdriver/Simulator.java
@@ -61,10 +61,8 @@ public class Simulator implements Runnable {
     @Override
     public void run() {
         logger.info("Starting Activity for " + this.baseUrl + " with " + this.iterations + " iterations.");
-
+        WebDriver driver = new ChromeDriver();
         try {
-            WebDriver driver = new ChromeDriver();
-
             for (int i = MIN; i <= this.iterations; i++) {
                 Randomizer randomizer = new Randomizer();
                 String email = faker.internet().emailAddress();
@@ -154,6 +152,8 @@ public class Simulator implements Runnable {
             driver.quit();
         } catch (Exception e) {
             logger.error("Error: " + e);
+        } finally {
+            driver.quit();
         }
 
     }


### PR DESCRIPTION
This PR introduces a new permanent feature flag called
max-selenium-threads which allows us to specify the number of concurrent
tests to run when executing the selenium simulator.

This also bumps the version of Selenium to a more recent release which
fixed a bug where multiple versions of chrome were being launched.