### PR TITLE
dev: Use Github actions for simulator

### DIFF
--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -13,10 +13,8 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
-          sudo curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add
-          sudo echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
-          sudo apt-get -y update
-          sudo apt-get -y install google-chrome-stable
+          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
           wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
           unzip chromedriver_linux64.zip
           sudo mv chromedriver /usr/bin/chromedriver
@@ -30,6 +28,9 @@ jobs:
         env:
           LD_API_KEY: ${{ secrets.LD_API_KEY }}
           LD_CLIENT_KEY: ${{ secrets.LD_CLIENT_KEY }}
+          DISPLAY: :99
+          CHROME_BIN: /usr/bin/google-chrome
         run: |
           cd tests/webdriver
+          Xvfb :99 -screen 0 1280x1024x24 &
           java -jar target/webdriver-1.0-SNAPSHOT-jar-with-dependencies.jar

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Install Dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y chromium-browser chromium-chromedriver
       - name: Install Simulator
         run: |
           cd tests/webdriver

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -8,6 +8,7 @@ jobs:
     name: Simulate
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v1
       - name: Install Simulator
         run: |
           cd tests/webdriver

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -14,7 +14,7 @@ jobs:
           sudo apt update
           sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
           wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-          dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
+          sudo dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
           wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
           unzip chromedriver_linux64.zip
           sudo mv chromedriver /usr/bin/chromedriver

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -1,7 +1,9 @@
 name: Run Selenium Simulator
-on:
-  schedule:
-    - cron: '*/15 * * * *'
+# Commenting this out for now because using schedule appears to break GitHub Actions
+# on:
+#   schedule:
+#     - cron: '*/15 * * * *'
+on: push
 jobs:
   simualte:
     name: Simulate

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
-          sudo curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
+          sudo curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add
           sudo echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get -y update
           sudo apt-get -y install google-chrome-stable

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -14,7 +14,7 @@ jobs:
           sudo apt update
           sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
           wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-          sudo dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
+          sudo dpkg -i google-chrome-stable_current_amd64.deb; sudo apt-get -fy install
           wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
           unzip chromedriver_linux64.zip
           sudo mv chromedriver /usr/bin/chromedriver

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -1,0 +1,18 @@
+name: Run Selenium Simulator
+# on:
+#   schedule:
+#     - cron: '0 * * * *'
+on: push
+jobs:
+  simualte:
+    name: Simulate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Simulator
+        run: |
+          cd tests/webdriver
+          mv compile assembly:single
+      - name: Run Simulation
+        run: |
+          cd tests/webdriver
+          java -jar target/webdriver-1.0-SNAPSHOT-jar-with-dependencies.jar

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -1,8 +1,7 @@
 name: Run Selenium Simulator
-# on:
-#   schedule:
-#     - cron: '0 * * * *'
-on: push
+on:
+  schedule:
+    - cron: '*/15 * * * *'
 jobs:
   simualte:
     name: Simulate

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -14,6 +14,9 @@ jobs:
           cd tests/webdriver
           mvn compile assembly:single
       - name: Run Simulation
+        env:
+          LD_API_KEY: ${{ secrets.LD_API_KEY }}
+          LD_CLIENT_KEY: ${{ secrets.LD_CLIENT_KEY }}
         run: |
           cd tests/webdriver
           java -jar target/webdriver-1.0-SNAPSHOT-jar-with-dependencies.jar

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -12,7 +12,16 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt update
-          sudo apt install -y chromium-browser chromium-chromedriver
+          sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
+          sudo curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
+          sudo echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get -y update
+          sudo apt-get -y install google-chrome-stable
+          wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
+          unzip chromedriver_linux64.zip
+          sudo mv chromedriver /usr/bin/chromedriver
+          sudo chown root:root /usr/bin/chromedriver
+          sudo chmod +x /usr/bin/chromedriver
       - name: Install Simulator
         run: |
           cd tests/webdriver

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Simulator
         run: |
           cd tests/webdriver
-          mv compile assembly:single
+          mvn compile assembly:single
       - name: Run Simulation
         run: |
           cd tests/webdriver


### PR DESCRIPTION
This PR introduces a GH Actions workflow to execute our simulator.

Note. Using the `schedule` key appears to break GitHub actions. Switching to `push` for now, once this issue has been resolved I will submit another PR to introduce the schedule. 