### PR TITLE
ops: Tune postgres and workers

### DIFF
--- a/app/cli/templates/docker-compose.prod.jinja
+++ b/app/cli/templates/docker-compose.prod.jinja
@@ -28,6 +28,7 @@ services:
     environment:
       - POSTGRES_USER=supportService
       - POSTGRES_PASSWORD=supportService
+    command: ["-c", "max_connections=10000"]
     volumes:
       - ./data:/var/lib/postgresql/data
     ports:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,4 +7,4 @@ done
 
 >&2 echo "Postgres is up, starting SupportService"
 flask db upgrade > /dev/null 2>&1
-ddtrace-run gunicorn "app.factory:application" -b 0.0.0.0:$1
+ddtrace-run gunicorn "app.factory:application" -w 5 -b 0.0.0.0:$1


### PR DESCRIPTION
This commit increases max_connections to 10,000 and sets the number of
workers that gunicorn starts with to 5.