### PR TITLE
core: Stop indexing anonymous users

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -66,7 +66,10 @@ class User(UserMixin, db.Model):
         return user
 
     def get_random_ld_user(self):
-        user = {'key': str(uuid.uuid1())}
+        user = {
+            'key': str(uuid.uuid1()),
+            'anonymous': True
+        }
         return user
 
 


### PR DESCRIPTION
This commit fixed an issue where we were indexing a bunch of GUID because the get_random_ld_user function did not set anonymous to true.