### PR TITLE
core: update JS SDK to using unpkg

### DIFF
--- a/app/templates/beta/base.html
+++ b/app/templates/beta/base.html
@@ -1,7 +1,7 @@
 {% extends 'bootstrap/base.html' %}
 
 {% block head %}
-    <script crossorigin="anonymous" src="https://app.launchdarkly.com/snippet/ldclient.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/launchdarkly-js-client-sdk@2"></script>
     <script>
             var ldclient = LDClient.initialize("{{ LD_FRONTEND_KEY }}", {{ current_user.get_ld_user() | safe }}, options = {
                 bootstrap: {{ all_flags | safe }}                

--- a/app/templates/default/base.html
+++ b/app/templates/default/base.html
@@ -24,7 +24,7 @@
    <script src="{{ url_for('static', filename='light/dist/js/sb-admin-2.min.js') }}"></script>
 
 
-    <script crossorigin="anonymous" src="https://app.launchdarkly.com/snippet/ldclient.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/launchdarkly-js-client-sdk@2"></script>
     <script>
             var ldclient = LDClient.initialize("{{ LD_FRONTEND_KEY }}", {{ current_user.get_ld_user() | safe }}, options = {
                 bootstrap: {{ all_flags | safe }}                

--- a/app/templates/main.html
+++ b/app/templates/main.html
@@ -37,7 +37,7 @@
    <script src="{{ url_for('static', filename='light/dist/js/sb-admin-2.min.js') }}"></script>
 
 
-    <script crossorigin="anonymous" src="https://app.launchdarkly.com/snippet/ldclient.min.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/launchdarkly-js-client-sdk@2"></script>
     <script>
             var ldclient = LDClient.initialize("{{ config['LD_FRONTEND_KEY'] }}", {{ current_user.get_ld_user() | safe }} );
     </script>


### PR DESCRIPTION
This will grant more control over JS SDK updates since the existing method is frozen at release 2.10.1. This will also add the support for experimentation's new functionalities