### PR TITLE
core: fix early feature flag evaluation errors

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -61,12 +61,13 @@ class DevelopmentConfig(Config):
     def init_app(app):
         Config.init_app(app)
         with app.app_context():
+            setup_ld_client(app)
+
             from app.db import db
             from app.models import User
             from app.models import Plan
 
             db.init_app(app)
-            setup_ld_client(app)
             db.create_all()
 
             # check if plans exist

--- a/app/factory.py
+++ b/app/factory.py
@@ -19,7 +19,6 @@ from app.config import config
 from app.util import getLdMachineUser
 from app.ld import LaunchDarklyApi
 from app.cli.generators import ConfigGenerator
-from app.models import User
 from app.db import db
 
 
@@ -59,6 +58,7 @@ class SubdomainDispatcher(object):
         app = self.get_application(environ['HTTP_HOST'])
         @login.user_loader
         def load_user(id):
+            from app.models import User
             return User.query.get(id)
         return app(environ, start_response)
 


### PR DESCRIPTION
Flask's cached decorator was getting called too early, as it result it is access the "CACHE_TIMEOUT()" and "CachingDisabled()" feature flags. 

This is causing the ldclient to evaluate feature flags before its even initialized.

This change will allow the User class to be imported _after_ the flask instance is intialized.