### PR TITLE
core: class instantiation, environment fixes

### DIFF
--- a/app/admin_ldclient.py
+++ b/app/admin_ldclient.py
@@ -1,0 +1,28 @@
+import os
+import ldclient
+from ldclient import Config as LdConfig
+from app.ld import LaunchDarklyApi
+
+
+class AdminClient:
+    PROJECT_NAME = 'support-service'
+
+    def __init__(self):
+        self.ld = LaunchDarklyApi(os.environ.get('LD_API_KEY'))
+        self.project = self.ld.get_project(AdminClient.PROJECT_NAME)
+
+
+    def admin_ldclient(self):
+        for env in self.project.environments:
+            if env.name == 'admin':
+                admin_env = env
+                break
+
+        ld_config = LdConfig(
+            sdk_key = admin_env.api_key,
+            connect_timeout = 30,
+            read_timeout = 30
+        )
+        return ldclient.LDClient(config=ld_config)
+
+admin_ldclient = AdminClient().admin_ldclient()

--- a/app/cache.py
+++ b/app/cache.py
@@ -1,12 +1,11 @@
-import ldclient
+from flask import current_app as app
 from flask_caching import Cache
 
 from app.util import getLdMachineUser
 
 cache = Cache()
+#with app.app_context():
+#    CACHE_TIMEOUT = lambda : app.ldclient.variation('cache-timeout', getLdMachineUser(), 50)
 
-# Operational Feature Flags
-CACHE_TIMEOUT = lambda : ldclient.get().variation('cache-timeout', getLdMachineUser(), 50)
-
-def CachingDisabled():
-    return ldclient.get().variation('disable-caching', getLdMachineUser(), True)
+#def CachingDisabled(app):
+#    return app.ldclient.variation('disable-caching', getLdMachineUser(), True)

--- a/app/cache.py
+++ b/app/cache.py
@@ -1,11 +1,12 @@
-from flask import current_app as app
+
 from flask_caching import Cache
 
+from app.admin_ldclient import admin_ldclient
 from app.util import getLdMachineUser
 
 cache = Cache()
-#with app.app_context():
-#    CACHE_TIMEOUT = lambda : app.ldclient.variation('cache-timeout', getLdMachineUser(), 50)
 
-#def CachingDisabled(app):
-#    return app.ldclient.variation('disable-caching', getLdMachineUser(), True)
+CACHE_TIMEOUT = lambda : admin_ldclient.variation('cache-timeout', getLdMachineUser(), 50)
+
+def caching_disabled():
+    return admin_ldclient.variation('disable-caching', getLdMachineUser(), True)

--- a/app/cli/templates/docker-compose.prod.jinja
+++ b/app/cli/templates/docker-compose.prod.jinja
@@ -10,6 +10,7 @@ services:
       - FLASK_ENV=production
       - LD_API_KEY={{ env("LD_API_KEY") }}
       - REDIS_HOST=cache
+      - REDIS_URL=redis://cache:6379/0
       - AWS_ACCOUNT_ID={{ env("AWS_ACCOUNT_ID") }}
       - DATADOG_HOST=datadog-agent
       - DD_AGENT_HOST=datadog-agent

--- a/app/config.py
+++ b/app/config.py
@@ -118,7 +118,6 @@ class StagingConfig(Config):
     @staticmethod
     def init_app(app):
         Config.init_app(app)
-        setup_ld_client(app)
         with app.app_context():
             from app.db import db
             from app.models import User
@@ -134,7 +133,6 @@ class ProductionConfig(Config):
     @staticmethod
     def init_app(app):
         Config.init_app(app)
-        setup_ld_client(app)
         with app.app_context():
             from app.db import db
             from app.models import User
@@ -149,25 +147,3 @@ config = {
     'staging': StagingConfig,
     'default': DevelopmentConfig
 }
-
-def setup_ld_client(app):
-    # define and set required env vars
-    new_client = ldclient.LDClient()
-    LD_CLIENT_KEY = env_var("LD_CLIENT_KEY", app.config['LD_CLIENT_KEY'], required=True)
-    LD_FRONTEND_KEY = env_var("LD_FRONTEND_KEY", app.config['LD_FRONTEND_KEY'], required=True)
-
-    # LaunchDarkly Config
-    # If $LD_RELAY_URL is set, client will be pointed to a relay instance.
-    if "LD_RELAY_URL" in os.environ:
-        base_uri = os.environ.get("LD_RELAY_URL")
-        config = LdConfig(
-            sdk_key = app.config.LD_CLIENT_KEY,
-            base_uri = base_uri,
-            events_uri = os.environ.get("LD_RELAY_EVENTS_URL", base_uri),
-            stream_uri = os.environ.get("LD_RELAY_STREAM_URL", base_uri)
-        )
-        new_client.set_config(config)
-    else:
-        new_client.set_sdk_key(LD_CLIENT_KEY)
-
-    return new_client

--- a/app/config.py
+++ b/app/config.py
@@ -66,7 +66,6 @@ class DevelopmentConfig(Config):
             from app.models import Plan
 
             db.init_app(app)
-            setup_ld_client(app)
             db.create_all()
 
             # check if plans exist
@@ -153,6 +152,7 @@ config = {
 
 def setup_ld_client(app):
     # define and set required env vars
+    new_client = ldclient.LDClient()
     LD_CLIENT_KEY = env_var("LD_CLIENT_KEY", app.config['LD_CLIENT_KEY'], required=True)
     LD_FRONTEND_KEY = env_var("LD_FRONTEND_KEY", app.config['LD_FRONTEND_KEY'], required=True)
 
@@ -166,6 +166,8 @@ def setup_ld_client(app):
             events_uri = os.environ.get("LD_RELAY_EVENTS_URL", base_uri),
             stream_uri = os.environ.get("LD_RELAY_STREAM_URL", base_uri)
         )
-        ldclient.set_config(config)
+        new_client.set_config(config)
     else:
-        ldclient.set_sdk_key(LD_CLIENT_KEY)
+        new_client.set_sdk_key(LD_CLIENT_KEY)
+
+    return new_client

--- a/app/config.py
+++ b/app/config.py
@@ -42,7 +42,7 @@ class Config(object):
     LOG_TO_STDOUT = os.environ.get('LOG_TO_STDOUT')
     REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
     CACHE_REDIS_HOST = REDIS_HOST
-    REDIS_URL = os.environ.get('REDIS_URL')
+    REDIS_URL = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
     CACHE_CONFIG = {'CACHE_TYPE': 'simple'}
 
     root = logging.getLogger()

--- a/app/factory.py
+++ b/app/factory.py
@@ -172,9 +172,6 @@ def build_environment(app):
 
     return app
 
-def CachingDisabled(app):
-    return app.ldclient.variation('disable-caching', getLdMachineUser(), True)
-
 def rundevserver(host='0.0.0.0', port=5000, domain='localhost', **options):
     """
     Modified from `flask.Flask.run`

--- a/app/factory.py
+++ b/app/factory.py
@@ -74,7 +74,6 @@ def create_app(env_id, env_api_key, config_name):
     :returns: a flask application
     """
     app = Flask(__name__)
-    app = build_environment(app)
     if env_api_key:
         app.config['LD_CLIENT_KEY'] = env_api_key
         logging.info(env_api_key)
@@ -83,6 +82,7 @@ def create_app(env_id, env_api_key, config_name):
         logging.info(env_id)
     app.config.from_object(config[config_name])
     config[config_name].init_app(app)
+    app = build_environment(app)
     app.ldclient = setup_ld_client(app)
     app.logger.info("APP VERSION: " + app.config['VERSION'])
 
@@ -182,7 +182,6 @@ def setup_ld_client(app):
 def build_environment(app):
     if os.environ.get('TESTING') is None or os.environ.get('TESTING') == False:
         app.redis_client = FlaskRedis(app)
-
     return app
 
 def rundevserver(host='0.0.0.0', port=5000, domain='localhost', **options):

--- a/app/factory.py
+++ b/app/factory.py
@@ -53,6 +53,8 @@ class SubdomainDispatcher(object):
             app = self.instances.get(subdomain)
             if app is None:
                 app = make_app(self.ld, self.rclient, subdomain, self.config_name)
+                if app is None:
+                    return NotFound()
                 self.instances[subdomain] = app
             return app
 
@@ -140,7 +142,7 @@ def make_app(ld, rclient, subdomain, config_name):
         if env.key == subdomain:
             return create_app(env.id, env.api_key, config_name)
 
-    return NotFound()
+    return None
 
 def setup_ld_client(app):
     # define and set required env vars

--- a/app/factory.py
+++ b/app/factory.py
@@ -148,7 +148,7 @@ def setup_ld_client(app):
     redis_conn = "redis://" + app.config['REDIS_HOST'] + ":6379"
     if os.environ.get('TESTING') is None or os.environ.get('TESTING') == False:
         store = Redis.new_feature_store(url=redis_conn,
-            prefix=redis_prefix, caching=CacheConfig(expiration=0))
+            prefix=redis_prefix, caching=CacheConfig.disabled())
     elif os.environ.get('FLASK_ENV') == "default":
         store = InMemoryFeatureStore()
     else:

--- a/app/factory.py
+++ b/app/factory.py
@@ -5,6 +5,8 @@ import pickle
 
 import ldclient
 from ldclient import Config as LdConfig
+from ldclient.feature_store import CacheConfig
+from ldclient.integrations import Redis
 
 import redis
 
@@ -142,12 +144,17 @@ def make_app(ld, rclient, subdomain, config_name):
 
 def setup_ld_client(app):
     # define and set required env vars
+    redis_prefix = app.config['LD_FRONTEND_KEY'] + "-featurestore"
+    store = Redis.new_feature_store(url="redis:/" + app.config['REDIS_HOST'],
+    prefix=redis_prefix, caching=CacheConfig(expiration=0))
+
     LD_CLIENT_KEY = app.config['LD_CLIENT_KEY']
     LD_FRONTEND_KEY = app.config['LD_FRONTEND_KEY']
     ld_config = LdConfig(
         sdk_key = LD_CLIENT_KEY,
         connect_timeout = 30,
-        read_timeout = 30
+        read_timeout = 30,
+        feature_store = store
     )
 
     # LaunchDarkly Config

--- a/app/factory.py
+++ b/app/factory.py
@@ -5,7 +5,7 @@ import pickle
 
 import ldclient
 from ldclient import Config as LdConfig
-from ldclient.feature_store import CacheConfig
+from ldclient.feature_store import CacheConfig, InMemoryFeatureStore
 from ldclient.integrations import Redis
 
 import redis
@@ -145,8 +145,13 @@ def make_app(ld, rclient, subdomain, config_name):
 def setup_ld_client(app):
     # define and set required env vars
     redis_prefix = app.config['LD_FRONTEND_KEY'] + "-featurestore"
-    store = Redis.new_feature_store(url="redis:/" + app.config['REDIS_HOST'],
-    prefix=redis_prefix, caching=CacheConfig(expiration=0))
+    if os.environ.get('TESTING') is None or os.environ.get('TESTING') == False:
+        store = Redis.new_feature_store(url="redis:/" + app.config['REDIS_HOST'],
+            prefix=redis_prefix, caching=CacheConfig(expiration=0))
+    elif os.environ.get('FLASK_ENV') == "default":
+        store = InMemoryFeatureStore()
+    else:
+        store = InMemoryFeatureStore()
 
     LD_CLIENT_KEY = app.config['LD_CLIENT_KEY']
     LD_FRONTEND_KEY = app.config['LD_FRONTEND_KEY']

--- a/app/factory.py
+++ b/app/factory.py
@@ -145,8 +145,9 @@ def make_app(ld, rclient, subdomain, config_name):
 def setup_ld_client(app):
     # define and set required env vars
     redis_prefix = app.config['LD_FRONTEND_KEY'] + "-featurestore"
+    redis_conn = "redis://" + app.config['REDIS_HOST'] + ":6379"
     if os.environ.get('TESTING') is None or os.environ.get('TESTING') == False:
-        store = Redis.new_feature_store(url="redis:/" + app.config['REDIS_HOST'],
+        store = Redis.new_feature_store(url=redis_conn,
             prefix=redis_prefix, caching=CacheConfig(expiration=0))
     elif os.environ.get('FLASK_ENV') == "default":
         store = InMemoryFeatureStore()

--- a/app/models.py
+++ b/app/models.py
@@ -8,6 +8,7 @@ from flask import current_app
 from flask_login import AnonymousUserMixin, UserMixin
 from werkzeug.security import check_password_hash, generate_password_hash
 
+from app.cache import cache, caching_disabled, CACHE_TIMEOUT
 from app.db import db
 
 fake = Faker()
@@ -43,6 +44,7 @@ class User(UserMixin, db.Model):
     def get_email_hash(self):
         return hashlib.md5(self.email.encode()).hexdigest()
 
+    @cache.cached(timeout=CACHE_TIMEOUT(), unless=caching_disabled(), key_prefix='-users')
     def get_ld_user(self):
         app_version = current_app.config['VERSION']
         milliseconds = int(round(time.time() * 1000))

--- a/app/models.py
+++ b/app/models.py
@@ -8,7 +8,6 @@ from flask import current_app
 from flask_login import AnonymousUserMixin, UserMixin
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from app.cache import cache, CachingDisabled, CACHE_TIMEOUT
 from app.db import db
 
 fake = Faker()
@@ -44,7 +43,6 @@ class User(UserMixin, db.Model):
     def get_email_hash(self):
         return hashlib.md5(self.email.encode()).hexdigest()
 
-    @cache.cached(timeout=CACHE_TIMEOUT(), unless=CachingDisabled(), key_prefix='-users')
     def get_ld_user(self):
         app_version = current_app.config['VERSION']
         milliseconds = int(round(time.time() * 1000))

--- a/app/routes.py
+++ b/app/routes.py
@@ -240,6 +240,7 @@ def upgrade():
 @core.route('/environments')
 def environments():
     webhook = current_app.ldclient.variation('environments-webhook', current_user.get_ld_user(), False)
+
     if webhook:
         try:
             ld = LaunchDarklyApi(os.environ.get('LD_API_KEY'))

--- a/app/routes.py
+++ b/app/routes.py
@@ -5,12 +5,12 @@ import botocore
 import os
 import time
 import pickle
-#import ldclient
 from flask import (abort, Blueprint, current_app, flash, redirect, render_template,
                    request, url_for, session, jsonify)
 from flask_login import current_user, login_required, login_user, logout_user
 from werkzeug.urls import url_parse
 
+from app.cache import cache, CACHE_TIMEOUT, caching_disabled
 from app.factory import db, PROJECT_NAME
 from app.ld import LaunchDarklyApi
 from app.models import User, Plan
@@ -203,8 +203,7 @@ def profile():
     )
 
 @core.route('/people')
-#@cache.cached(timeout=cache_time, unless=cache_disabled)
-#@cache.cached(unless=current_app.CachingDisabled())
+@cache.cached(timeout=CACHE_TIMEOUT(), unless=caching_disabled())
 @login_required
 def people():
     page = request.args.get('page', 1, type=int)

--- a/app/routes.py
+++ b/app/routes.py
@@ -5,13 +5,12 @@ import botocore
 import os
 import time
 import pickle
-import ldclient
+#import ldclient
 from flask import (abort, Blueprint, current_app, flash, redirect, render_template,
                    request, url_for, session, jsonify)
 from flask_login import current_user, login_required, login_user, logout_user
 from werkzeug.urls import url_parse
 
-from app.cache import CachingDisabled, CACHE_TIMEOUT, cache
 from app.factory import db, PROJECT_NAME
 from app.ld import LaunchDarklyApi
 from app.models import User, Plan
@@ -36,7 +35,7 @@ def index():
     session['ld_user'] = user
 
     flag_name = 'trial-duration'
-    trial_duration = ldclient.get().variation_detail(
+    trial_duration = current_app.ldclient.variation_detail(
         flag_name,
         user,
         False)
@@ -52,7 +51,7 @@ def index():
         'variation': trial_duration.variation_index,
         'time': end_time,
     }
-    ldclient.get().track('trial-rendering', user, data_export)
+    current_app.ldclient.track('trial-rendering', user, data_export)
 
     session['trial_duration'] = trial_duration.value
 
@@ -65,7 +64,7 @@ def dashboard():
     if theme:
         updateTheme(theme)
 
-    beta_features = ldclient.get().variation('dark-theme', current_user.get_ld_user(), False)
+    beta_features = current_app.ldclient.variation('dark-theme', current_user.get_ld_user(), False)
 
     set_theme = '{0}/index.html'.format(current_user.set_path)
 
@@ -94,7 +93,7 @@ def experiments():
 
     random_user = current_user.get_random_ld_user()
 
-    show_nps = ldclient.get().variation('show-nps-survery', random_user, False)
+    show_nps = current_app.ldclient.variation('show-nps-survery', random_user, False)
 
     return render_template(set_theme, title='Experiments', show_nps=show_nps, random_user=random_user)
 
@@ -142,7 +141,7 @@ def register():
     # page by clicking a link on the home page (where they saw the ab test)
     if session.get('ld_user'):
         current_app.logger.info("Sending track event for {0}".format(session.get('ld_user')))
-        ldclient.get().track('started-registration', session['ld_user'])
+        current_app.ldclient.track('started-registration', session['ld_user'])
 
     if current_user.is_authenticated:
         return redirect(url_for('core.dashboard'))
@@ -167,7 +166,7 @@ def register():
         # page by clicking a link on the home page (where they saw the ab test)
         if session.get('ld_user'):
             current_app.logger.info("Sending track event for {0}".format(session.get('ld_user')))
-            ldclient.get().track('registered', session['ld_user'])
+            current_app.ldclient.track('registered', session['ld_user'])
 
         login_user(user)
         return redirect(url_for('core.dashboard'))
@@ -204,7 +203,8 @@ def profile():
     )
 
 @core.route('/people')
-@cache.cached(timeout=CACHE_TIMEOUT(), unless=CachingDisabled())
+#@cache.cached(timeout=cache_time, unless=cache_disabled)
+#@cache.cached(unless=current_app.CachingDisabled())
 @login_required
 def people():
     page = request.args.get('page', 1, type=int)
@@ -240,7 +240,7 @@ def upgrade():
 
 @core.route('/environments')
 def environments():
-    webhook = ldclient.get().variation('environments-webhook', current_user.get_ld_user(), False)
+    webhook = current_app.ldclient.variation('environments-webhook', current_user.get_ld_user(), False)
     if webhook:
         try:
             ld = LaunchDarklyApi(os.environ.get('LD_API_KEY'))

--- a/app/routes.py
+++ b/app/routes.py
@@ -248,7 +248,8 @@ def environments():
             project_pick = pickle.dumps(project)
             current_app.redis_client.set(PROJECT_NAME, project_pick)
             return jsonify({'response': 200})
-        except:
+        except Exception as e:
+            current_app.logger.error(e)
             return jsonify({'response': 400})
     else:
         abort(404)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,11 +7,11 @@
 # the latest docker image and restarts docker-compose.
 #
 # We have two enrivonments: production and staging. Please specify which host target
-# you wish to deploy when executing the script. For example, to deploy to production, 
+# you wish to deploy when executing the script. For example, to deploy to production,
 # execute "deploy.sh production".
 
 if [ -z "$1" ]
-  then 
+  then
   	echo "ERROR: no environment argument supplied"
   	exit 1
   else
@@ -31,5 +31,4 @@ scp -o StrictHostKeyChecking=no docker-compose.prod.yml $SERVER:/var/www/app/doc
 ssh -o StrictHostKeyChecking=no $SERVER 'docker system prune -a --force --volumes'
 
 # Log into Production Server, Pull and Restart Docker
-ssh -o StrictHostKeyChecking=no $SERVER 'cd /var/www/app && docker stack deploy --prune -c docker-compose.yml support-service'
-
+ssh -o StrictHostKeyChecking=no $SERVER 'cd /var/www/app && docker stack deploy --resolve-image always --prune -c docker-compose.yml support-service'


### PR DESCRIPTION
This PR has grown as issues have been encountered.

- Each Flask instance now has a proper client instantiated for that specific app to map to LaunchDarkly environment.
- Python Server SDK is now using Redis for feature store so there's a single view of the world from both containers.
- /environments webhook now works to provision new environments without having to do an app restart.
- Flask was creating an instance that would only return 404 if you tried to visit a subdomain before the key existed in Redis.
- There is now a global admin_ldclient tied to the `admin` environment of LaunchDarkly. This is to control global features like caching in blueprints. It can also be used in the automation of provisioning environments via the webhook above.