### PR TITLE
core: flush cache on plan change

### DIFF
--- a/app/factory.py
+++ b/app/factory.py
@@ -89,7 +89,8 @@ def create_app(env_id, env_api_key, config_name):
     app.logger.info("APP VERSION: " + app.config['VERSION'])
 
     bootstrap.init_app(app)
-    cache_config = { **app.config['CACHE_CONFIG'], 'CACHE_KEY_PREFIX': env_id }
+    flask_cache_key = env_id + "-flask-"
+    cache_config = { **app.config['CACHE_CONFIG'], 'CACHE_KEY_PREFIX': flask_cache_key }
     cache.init_app(app, config=cache_config)
     login.init_app(app)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -233,6 +233,8 @@ def settings():
 def upgrade():
     current_user.plan_id = request.args.get('plan')
     db.session.commit()
+    with current_app.app_context():
+        cache.clear()
 
     return redirect(request.referrer)
 


### PR DESCRIPTION
Add length to prefix so it doesn't clobber SDK keys when clearing