### PR TITLE
Rename beta_features/show_beta vars to dark_theme

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -84,7 +84,7 @@ def dashboard():
     if theme:
         updateTheme(theme)
 
-    beta_features = current_app.ldclient.variation(
+    dark_theme = current_app.ldclient.variation(
         "dark-theme", user, False
     )
 
@@ -96,7 +96,7 @@ def dashboard():
     return render_template(
         set_theme,
         title="Home",
-        show_beta=beta_features,
+        dark_theme=dark_theme,
         user_template=user_template,
         all_flags=bootstrap.to_json_string(),
     )

--- a/app/templates/default/base.html
+++ b/app/templates/default/base.html
@@ -60,7 +60,7 @@
         <ul class="nav navbar-top-links navbar-right">
             <!-- 
             {# 
-                {% if show_beta %}
+                {% if dark_theme %}
                 <li>
                     <a href="{{ url_for('updateTheme') }}">
                         <i class="fa fa-adjust fa-fw"></i>
@@ -267,7 +267,7 @@
                 <ul class="dropdown-menu dropdown-user">
                     <li><a href="#"><i class="fa fa-user fa-fw"></i> User Profile</a>
                     </li> 
-                    {% if show_beta %}
+                    {% if dark_theme %}
                     <li><a href="{{ url_for('core.dashboard', theme='dark') }}"><i class="fa fa-adjust fa-fw"></i> Dark Theme</a>
                     </li>
                     {% endif %}

--- a/app/templates/partials/nav.html
+++ b/app/templates/partials/nav.html
@@ -16,7 +16,7 @@
         <ul class="nav navbar-top-links navbar-right">
             <!-- 
             {# 
-                {% if show_beta %}
+                {% if dark_theme %}
                 <li>
                     <a href="{{ url_for('updateTheme') }}">
                         <i class="fa fa-adjust fa-fw"></i>
@@ -223,7 +223,7 @@
                 <ul class="dropdown-menu dropdown-user">
                     <li><a href="{{ url_for('core.profile') }}"><i class="fa fa-user fa-fw"></i> User Profile</a>
                     </li> 
-                    {% if show_beta %}
+                    {% if dark_theme %}
                     <li><a href="{{ url_for('core.dashboard', theme='dark') }}"><i class="fa fa-adjust fa-fw"></i> Dark Theme</a>
                     </li>
                     {% endif %}


### PR DESCRIPTION
... for consistency with the flag name (which is currently "dark-theme" - maybe we should rename the flag to use an underscore).

The use of both `beta_features` and `show_beta` to represent a flag with yet another name is confusing when reading the code, and (more importantly) when trying to explain the code during a demo.