### PR TITLE
circleci: change aws production deploy, add https target group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
       - checkout
       - aws-cli/setup:
           profile-name: circle-ci
-      - run: aws deploy create-deployment --application-name AppECS-flask-app-cluster-ss-blue-green --deployment-group-name DgpECS-flask-app-cluster-ss-blue-green --revision revisionType=S3,s3Location="{bucket=support-service-codedeploy,key=appspec.yaml,bundleType=yaml}"
+      - run: aws deploy create-deployment --application-name AppECS-flask-app-cluster-ss-production --deployment-group-name DgpECS-flask-app-cluster-ss-production --revision revisionType=S3,s3Location="{bucket=support-service-codedeploy,key=appspec.yaml,bundleType=yaml}"
   simulate:
     docker:
       - image: circleci/openjdk:11-node-browsers


### PR DESCRIPTION
Previous ECS service "ss-blue-green" was not configured to support HTTPS target groups.

This is changing the circle orb to use the new CodeDeploy application for the new ECS service --> ss-production