### PR TITLE
add g++ to base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Production Dockerfile for SupportService
 FROM python:3.6-alpine
 
-RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev bash git libffi-dev make
+RUN apk update && apk add postgresql-dev gcc g++ python3-dev musl-dev bash git libffi-dev make
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 # Production Dockerfile for SupportService
 FROM python:3.6-alpine
 
-RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev bash git libffi-dev make
+RUN apk update && apk add postgresql-dev gcc g++ python3-dev musl-dev bash git libffi-dev make
 
 WORKDIR /usr/src/app
 COPY requirements.txt .

--- a/Dockerfile.ecr
+++ b/Dockerfile.ecr
@@ -1,6 +1,6 @@
 FROM python:3.6-alpine
 
-RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev bash git libffi-dev make
+RUN apk update && apk add postgresql-dev gcc g++ python3-dev musl-dev bash git libffi-dev make
 
 ENV FLASK_ENV=production
 


### PR DESCRIPTION
This package appears to now be required to build some
underlying python dependency.