### PR TITLE
Dependencies: Specify Werkzeug version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,9 @@ flask-wtf==0.14.2
 flask-caching==1.7.1
 flask-fixtures==0.3.8
 
+# Werkzeug
+Werkzeug==1.0.1
+
 # Libraries
 faker>=1.0.7
 


### PR DESCRIPTION
This commit specifies a specific Werkzeug version to avoid the following error:

`ModuleNotFoundError: No module named 'werkzeug.posixemulation'`

This was happening on all requests on a fresh local install because Werkzeug was using the latest version (2.0.1 in my case). The posixemulation module was removed in 2.0.0, however, and it doesn't appear Flask was specifying a version to use. I included version 1.0.1 specifically because it was the last release prior to 2.0.0.